### PR TITLE
Add support for V1 varnishstat output

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -66,10 +66,31 @@ jobs:
         run: |
           .\build\windows\unit_tests.ps1
 
+  test-integration-nix:
+    name: Run integration tests on *Nix
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{env.GO_VERSION}}
+      - name: Integration test
+        env:
+          GOPATH: ${{ github.workspace }}
+        run: make integration-test
+
   prerelease:
     name: Build binary for *Nix/Win, create archives for *Nix/Win, create packages for *Nix, upload all artifacts into GH Release assets
     runs-on: ubuntu-20.04
-    needs: [test-nix, test-windows, snyk]
+    needs: [test-nix, test-windows, test-integration-nix, snyk]
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -84,6 +84,33 @@ jobs:
         run: |
           .\build\windows\unit_tests.ps1
 
+  test-integration-nix:
+    name: Run integration tests on *Nix
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{env.GO_VERSION}}
+      - name: Login to DockerHub
+        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      - name: Integration test
+        env:
+          GOPATH: ${{ github.workspace }}
+        run: make integration-test
+
   build:
     name: Build binary for all platforms:arch
     runs-on: ubuntu-20.04

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,102 @@
+run:
+  timeout: 5m
+
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  gci:
+    local-prefixes: github.com/golangci/golangci-lint
+  #  goconst:
+  #    min-len: 2
+  #    min-occurrences: 2
+  gocyclo:
+    min-complexity: 10
+  golint:
+    min-confidence: 0.8
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - gocritic
+    - gocyclo
+    - gocognit
+    - errorlint   #only add if go > 1.13
+    - gofmt
+    - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - nestif
+    - nilerr
+    - noctx
+    - prealloc
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - goconst   #looks for repetitions of variables that should go on constant
+  # - godot
+  # - godox
+  # - interfacer
+  # - lll
+  # - goerr113    #Errors are not defined in the integration.
+  # - nakedret
+  # - nolintlint
+  # - testpackage
+  # - revive
+  # - wsl

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ test:
 	@echo "=== $(INTEGRATION) === [ test ]: running unit tests..."
 	@go test -race ./... -count=1
 
+integration-test:
+	@echo "=== $(INTEGRATION) === [ test ]: running integration tests..."
+	@docker-compose -f tests/integration/docker-compose.yml up -d --build
+	@go test -v -tags=integration ./tests/integration/. || (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
+	@docker-compose -f tests/integration/docker-compose.yml down
+
 install: compile
 	@echo "=== $(INTEGRATION) === [ install ]: installing bin/$(BINARY_NAME)..."
 	@sudo install -D --mode=755 --owner=root --strip $(ROOT)bin/$(BINARY_NAME) $(INTEGRATIONS_DIR)/bin/$(BINARY_NAME)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/golangci/golangci-lint v1.39.0
 	github.com/josephspurrier/goversioninfo v1.2.0
 	github.com/newrelic/infra-integrations-sdk v3.6.7+incompatible
+	github.com/stretchr/testify v1.7.0
+	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/tools v0.1.0
 	mvdan.cc/gofumpt v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,12 @@ github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=

--- a/src/metrics/metric_definitions.go
+++ b/src/metrics/metric_definitions.go
@@ -29,6 +29,8 @@ type varnishDefinition struct {
 	BackendConReuses         interface{} `stat_name:"backend_reuse" metric_name:"backend.connectionReuses" source_type:"Rate"`
 	BackendConRecycles       interface{} `stat_name:"backend_recycle" metric_name:"backend.connectionRecycles" source_type:"Rate"`
 	BackendConRetries        interface{} `stat_name:"backend_retry" metric_name:"backend.connectionRetries" source_type:"Rate"`
+	BackendRespUncacheable   interface{} `stat_name:"beresp_uncacheable" metric_name:"backend.respUncacheable" source_type:"Rate"`
+	BackendRespShortlived    interface{} `stat_name:"beresp_shortlived" metric_name:"backend.respShortlived" source_type:"Rate"`
 	FetchHead                interface{} `stat_name:"fetch_head" metric_name:"fetch.head" source_type:"Rate"`
 	FetchContentLength       interface{} `stat_name:"fetch_length" metric_name:"fetch.contentLength" source_type:"Rate"`
 	FetchChuncked            interface{} `stat_name:"fetch_chunked" metric_name:"fetch.chuncked" source_type:"Rate"`
@@ -59,6 +61,8 @@ type varnishDefinition struct {
 	MainObjectheads          interface{} `stat_name:"n_objecthead" metric_name:"main.objectheads" source_type:"Gauge"`
 	MainBackends             interface{} `stat_name:"n_backend" metric_name:"main.backends" source_type:"Gauge"`
 	MainExpired              interface{} `stat_name:"n_expired" metric_name:"main.expired" source_type:"Rate"`
+	MainPipe                 interface{} `stat_name:"n_pipe" metric_name:"main.pipe" source_type:"Rate"`
+	MainPipeLimited          interface{} `stat_name:"pipe_limited" metric_name:"main.pipe_limited" source_type:"Rate"`
 	LruNuked                 interface{} `stat_name:"n_lru_nuked" metric_name:"lru.nuked" source_type:"Rate"`
 	LruMoved                 interface{} `stat_name:"n_lru_moved" metric_name:"lru.moved" source_type:"Rate"`
 	LruLimited               interface{} `stat_name:"n_lru_limited" metric_name:"lru.limited" source_type:"Rate"`
@@ -79,6 +83,12 @@ type varnishDefinition struct {
 	SessClosedError          interface{} `stat_name:"sess_closed_err" metric_name:"sess.closedError" source_type:"Rate"`
 	SessReadAhead            interface{} `stat_name:"sess_readahead" metric_name:"sess.readAhead" source_type:"Rate"`
 	SessHerd                 interface{} `stat_name:"sess_herd" metric_name:"sess.herd" source_type:"Rate"`
+	SessFailEconnaborted     interface{} `stat_name:"sess_fail_econnaborted" metric_name:"sess.sessFailEconnaborted" source_type:"Rate"`
+	SessFailEmfile           interface{} `stat_name:"sess_fail_emfile" metric_name:"sess.sessFailEmfile" source_type:"Rate"`
+	SessFailEbadf            interface{} `stat_name:"sess_fail_ebadf" metric_name:"sess.sessFailEbadf" source_type:"Rate"`
+	SessFailEnomem           interface{} `stat_name:"sess_fail_enomem" metric_name:"sess.sessFailEnomem" source_type:"Rate"`
+	SessFailEintr            interface{} `stat_name:"sess_fail_eintr" metric_name:"sess.sessFailEintr" source_type:"Rate"`
+	SessFailOther            interface{} `stat_name:"sess_fail_other" metric_name:"sess.sessFailOther" source_type:"Rate"`
 	SessClientClose          interface{} `stat_name:"sc_rem_close" metric_name:"sess.clientClose" source_type:"Rate"`
 	SessClientReqClose       interface{} `stat_name:"sc_req_close" metric_name:"sess.clientReqClose" source_type:"Rate"`
 	SessReqHTTP10Close       interface{} `stat_name:"sc_req_http10" metric_name:"sess.requestHTTP10Close" source_type:"Rate"`
@@ -87,6 +97,7 @@ type varnishDefinition struct {
 	SessJunkClose            interface{} `stat_name:"sc_rx_junk" metric_name:"sess.junkClose" source_type:"Rate"`
 	SessOverflowClose        interface{} `stat_name:"sc_rx_overflow" metric_name:"sess.overflowClose" source_type:"Rate"`
 	SessTimeoutClose         interface{} `stat_name:"sc_rx_timeout" metric_name:"sess.timeoutClose" source_type:"Rate"`
+	SessCloseIdle            interface{} `stat_name:"sc_rx_close_idle" metric_name:"sess.closeIdle" source_type:"Rate"`
 	SessPipeTxnClose         interface{} `stat_name:"sc_tx_pipe" metric_name:"sess.pipeTxnClose" source_type:"Rate"`
 	SessErrorTxnClose        interface{} `stat_name:"sc_tx_error" metric_name:"sess.errorTxnClose" source_type:"Rate"`
 	SessEOFTxnClose          interface{} `stat_name:"sc_tx_eof" metric_name:"sess.eofTxnClose" source_type:"Rate"`
@@ -149,9 +160,11 @@ type varnishDefinition struct {
 
 // lockDefinition represents the data for a VarnishLockSample event
 type lockDefinition struct {
-	Created   interface{} `stat_name:"creat" metric_name:"lock.created" source_type:"Rate"`
-	Destroyed interface{} `stat_name:"destroy" metric_name:"lock.destroyed" source_type:"Rate"`
-	LockOps   interface{} `stat_name:"locks" metric_name:"lock.locks" source_type:"Rate"`
+	Created    interface{} `stat_name:"creat" metric_name:"lock.created" source_type:"Rate"`
+	Destroyed  interface{} `stat_name:"destroy" metric_name:"lock.destroyed" source_type:"Rate"`
+	LockOps    interface{} `stat_name:"locks" metric_name:"lock.locks" source_type:"Rate"`
+	DbgBusy    interface{} `stat_name:"dbg_busy" metric_name:"lock.dbg_busy" source_type:"Rate"`
+	DbgTryFail interface{} `stat_name:"dbg_try_fail" metric_name:"lock.dbg_try_fail" source_type:"Rate"`
 }
 
 // mempoolDefinition represents the data for a VarnishMempoolSample event
@@ -182,18 +195,24 @@ type storageDefinition struct {
 
 // backendDefinition represents the data to be set for a Backend Entity and VarnishBackendSample event
 type backendDefinition struct {
-	Happy           interface{} `stat_name:"happy" metric_name:"backend.happy" source_type:"Gauge"`
-	ReqHeader       interface{} `stat_name:"bereq_hdrbytes" metric_name:"net.backend.requestHeaderInBytes" source_type:"Rate"`
-	ReqBody         interface{} `stat_name:"bereq_bodybytes" metric_name:"net.backend.requestBodyInBytes" source_type:"Rate"`
-	RespHeader      interface{} `stat_name:"beresp_hdrbytes" metric_name:"net.backend.responseHeaderInBytes" source_type:"Rate"`
-	RespBody        interface{} `stat_name:"beresp_bodybytes" metric_name:"net.backend.responseBodyInBytes" source_type:"Rate"`
-	PipeHeader      interface{} `stat_name:"pipe_hdrbytes" metric_name:"net.backend.pipeHeaderInBytes" source_type:"Rate"`
-	PipeOut         interface{} `stat_name:"pipe_out" metric_name:"net.backend.pipeOutInBytes" source_type:"Rate"`
-	PipeIn          interface{} `stat_name:"pipe_in" metric_name:"net.backend.pipeInInBytes" source_type:"Rate"`
-	Connections     interface{} `stat_name:"conn" metric_name:"backend.connections" source_type:"Gauge"`
-	Req             interface{} `stat_name:"req" metric_name:"net.backend.requests" source_type:"Rate"`
-	UnhealtyFetches interface{} `stat_name:"unhealthy" metric_name:"backend.unhealthyFetches" source_type:"Rate"`
-	BusyFetches     interface{} `stat_name:"busy" metric_name:"backend.busyFetches" source_type:"Rate"`
-	ConFailed       interface{} `stat_name:"fail" metric_name:"backend.connectionsFailed" source_type:"Rate"`
-	ConNotAttempted interface{} `stat_name:"helddown" metric_name:"backend.connectionsNotAttempted" source_type:"Rate"`
+	Happy                  interface{} `stat_name:"happy" metric_name:"backend.happy" source_type:"Gauge"`
+	ReqHeader              interface{} `stat_name:"bereq_hdrbytes" metric_name:"net.backend.requestHeaderInBytes" source_type:"Rate"`
+	ReqBody                interface{} `stat_name:"bereq_bodybytes" metric_name:"net.backend.requestBodyInBytes" source_type:"Rate"`
+	RespHeader             interface{} `stat_name:"beresp_hdrbytes" metric_name:"net.backend.responseHeaderInBytes" source_type:"Rate"`
+	RespBody               interface{} `stat_name:"beresp_bodybytes" metric_name:"net.backend.responseBodyInBytes" source_type:"Rate"`
+	PipeHeader             interface{} `stat_name:"pipe_hdrbytes" metric_name:"net.backend.pipeHeaderInBytes" source_type:"Rate"`
+	PipeOut                interface{} `stat_name:"pipe_out" metric_name:"net.backend.pipeOutInBytes" source_type:"Rate"`
+	PipeIn                 interface{} `stat_name:"pipe_in" metric_name:"net.backend.pipeInInBytes" source_type:"Rate"`
+	Connections            interface{} `stat_name:"conn" metric_name:"backend.connections" source_type:"Gauge"`
+	Req                    interface{} `stat_name:"req" metric_name:"net.backend.requests" source_type:"Rate"`
+	UnhealtyFetches        interface{} `stat_name:"unhealthy" metric_name:"backend.unhealthyFetches" source_type:"Rate"`
+	BusyFetches            interface{} `stat_name:"busy" metric_name:"backend.busyFetches" source_type:"Rate"`
+	ConFailed              interface{} `stat_name:"fail" metric_name:"backend.connectionsFailed" source_type:"Rate"`
+	ConFailedEaccess       interface{} `stat_name:"fail_eacces" metric_name:"backend.connectionsFailedEacces" source_type:"Rate"`
+	ConFailedEconnrefused  interface{} `stat_name:"fail_econnrefused" metric_name:"backend.connectionsFailedEconnrefused" source_type:"Rate"`
+	ConFailedEtimedout     interface{} `stat_name:"fail_etimedout" metric_name:"backend.connectionsFailedEtimedout" source_type:"Rate"`
+	ConFailedEaddrnotavail interface{} `stat_name:"fail_eaddrnotavail" metric_name:"backend.connectionsFailedEaddrnotavail" source_type:"Rate"`
+	ConFailedEnetunreach   interface{} `stat_name:"fail_enetunreach" metric_name:"backend.connectionsFailedEnetunreach" source_type:"Rate"`
+	ConFailedOther         interface{} `stat_name:"fail_other" metric_name:"backend.connectionsFailedOther" source_type:"Rate"`
+	ConNotAttempted        interface{} `stat_name:"helddown" metric_name:"backend.connectionsNotAttempted" source_type:"Rate"`
 }

--- a/src/metrics/stat_parse.go
+++ b/src/metrics/stat_parse.go
@@ -1,3 +1,4 @@
+//nolint:goerr113
 package metrics
 
 import (

--- a/src/metrics/stat_parse.go
+++ b/src/metrics/stat_parse.go
@@ -1,4 +1,3 @@
-//nolint:goerr113
 package metrics
 
 import (
@@ -37,13 +36,13 @@ func parseStats(statsData []byte) (*varnishDefinition, map[string]*backendDefini
 	case 1:
 		counters, ok := stats["counters"].(map[string]interface{})
 		if !ok {
-			return nil, nil, fmt.Errorf("No 'counters' key found")
+			return nil, nil, fmt.Errorf("no 'counters' key found")
 		}
 
 		processStats(counters, varnishSystem, backends)
 
 	default:
-		return nil, nil, fmt.Errorf("Unsupported varnishstat results version: %v", version)
+		return nil, nil, fmt.Errorf("unsupported varnishstat results version: %v", version)
 	}
 
 	return varnishSystem, backends, nil
@@ -81,7 +80,6 @@ func processStats(stats map[string]interface{}, varnishSystem *varnishDefinition
 		}
 		// all other metrics under varnish system
 		parseAndSetStat(varnishSystem, fullStatName, statValue)
-
 	}
 }
 

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -8,10 +8,10 @@ import (
 const varnishStatTestResult = `{
 	"timestamp": "2018-11-05T17:22:34",
 	"backend_fail": {
-    "value": 0, 
-    "flag": "a", 
-    "description": "Backend conn. failures"
-  },
+		"value": 0,
+		"flag": "a",
+		"description": "Backend conn. failures"
+	},
 	"MGT.uptime": {
 		"description": "Management process uptime",
 		"flag": "c", "format": "d",
@@ -236,6 +236,145 @@ func Test_parseStats_Full(t *testing.T) {
 	}
 
 	varnishSystem, backends, err := parseStats([]byte(varnishStatTestResult))
+	if err != nil {
+		t.Fatalf("Unexpected error %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(varnishSystem, expectedVarnishSystem) {
+		t.Fatalf("Expected System of %+v got %+v", expectedVarnishSystem, varnishSystem)
+	}
+
+	if !reflect.DeepEqual(backends, expectedBackends) {
+		t.Fatalf("Expected Backends of %+v got %+v", expectedBackends, backends)
+	}
+}
+
+const varnishStatV1TestResult = `{
+	"version": 1,
+	"timestamp": "2021-06-23T15:25:46",
+	"counters": {
+		"MGT.uptime": {
+			"description": "Management process uptime",
+			"flag": "c",
+			"format": "d",
+			"value": 4173714
+		},
+		"MAIN.threads": {
+			"description": "Total number of threads",
+			"flag": "g",
+			"format": "i",
+			"value": 200
+		},
+		"LCK.backend.creat": {
+			"description": "Created locks",
+			"flag": "c",
+			"format": "i",
+			"value": 2
+		},
+		"LCK.backend.destroy": {
+			"description": "Destroyed locks",
+			"flag": "c",
+			"format": "i",
+			"value": 0
+		},
+		"LCK.backend.locks": {
+			"description": "Lock Operations",
+			"flag": "c",
+			"format": "i",
+			"value": 94958
+		},
+		"SMA.Transient.g_bytes": {
+			"description": "Bytes outstanding",
+			"flag": "g", "format": "B",
+			"value": 40
+		},
+		"SMA.Transient.g_space": {
+			"description": "Bytes available",
+			"flag": "g", "format": "B",
+			"value": 60
+		},
+		"MEMPOOL.busyobj.live": {
+			"description": "In use",
+			"flag": "g",
+			"format": "i",
+			"value": 0
+		},
+		"MEMPOOL.busyobj.pool": {
+			"description": "In Pool",
+			"flag": "g",
+			"format": "i",
+			"value": 10
+		},
+		"VBE.reload_20210601_145132_6770.upstream_1.fail_eacces": {
+			"description": "Connections failed with EACCES or EPERM",
+			"flag": "c",
+			"format": "i",
+			"value": 0
+		},
+		"VBE.reload_20210601_145132_6770.upstream_1.fail_eaddrnotavail": {
+			"description": "Connections failed with EADDRNOTAVAIL",
+			"flag": "c",
+			"format": "i",
+			"value": 0
+		},
+		"VBE.reload_20210601_145132_6770.upstream_1.fail_econnrefused": {
+			"description": "Connections failed with ECONNREFUSED",
+			"flag": "c",
+			"format": "i",
+			"value": 0
+		},
+		"VBE.reload_20210601_145132_6770.upstream_1.fail_enetunreach": {
+			"description": "Connections failed with ENETUNREACH",
+			"flag": "c",
+			"format": "i",
+			"value": 0
+		},
+		"VBE.reload_20210601_145132_6770.upstream_1.fail_etimedout": {
+			"description": "Connections failed ETIMEDOUT",
+			"flag": "c",
+			"format": "i",
+			"value": 0
+		}
+	}
+}`
+
+func Test_parseStats_FullV1(t *testing.T) {
+	expectedVarnishSystem := &varnishDefinition{
+		MgtUptime:   float64(4173714),
+		MainThreads: float64(200),
+
+		locks: map[string]*lockDefinition{
+			"backend": {
+				Created:   float64(2),
+				Destroyed: float64(0),
+				LockOps:   float64(94958),
+			},
+		},
+		storages: map[string]*storageDefinition{
+			"Transient": {
+				Outstanding: float64(40),
+				Available:   float64(60),
+			},
+		},
+		mempools: map[string]*mempoolDefinition{
+			"busyobj": {
+				Live: float64(0),
+				Pool: float64(10),
+			},
+		},
+	}
+
+	expectedBackends := map[string]*backendDefinition{
+		"reload_20210601_145132_6770.upstream_1": {
+			ConFailedEaccess:       float64(0),
+			ConFailedEaddrnotavail: float64(0),
+			ConFailedEconnrefused:  float64(0),
+			ConFailedEnetunreach:   float64(0),
+			ConFailedEtimedout:     float64(0),
+		},
+	}
+
+	varnishSystem, backends, err := parseStats([]byte(varnishStatV1TestResult))
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -338,6 +338,59 @@ const varnishStatV1TestResult = `{
 	}
 }`
 
+func Test_parseStats_uknownVersion(t *testing.T) {
+	testCases := []struct {
+		name       string
+		stats      string
+		expectFail bool
+	}{
+		{
+			"empty ok",
+			`{ "version": 0 }`,
+			false,
+		},
+		{
+			"bad json",
+			`{ "version": 0, }`,
+			true,
+		},
+		{
+			"unknown schema version",
+			`{ "version": 9.1 }`,
+			true,
+		},
+		{
+			"string version fail to cast",
+			`{ "version": "asdf" }`,
+			true,
+		},
+		{
+			"v1 missing counters entry",
+			`{
+				"version": 1,
+				"timestamp": "2021-06-23T15:25:46",
+				"MGT.uptime": {
+					"description": "Management process uptime",
+					"flag": "c",
+					"format": "d",
+					"value": 4173714
+				}
+			}`,
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, _, err := parseStats([]byte(tc.stats))
+		if tc.expectFail && err == nil {
+			t.Errorf("Test Case %s Failed: did not return error", tc.name)
+		}
+		if !tc.expectFail && err != nil {
+			t.Errorf("Test Case %s Failed: return error: %s", tc.name, err)
+		}
+	}
+}
+
 func Test_parseStats_FullV1(t *testing.T) {
 	expectedVarnishSystem := &varnishDefinition{
 		MgtUptime:   float64(4173714),

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.16 as builder
+ARG CGO_ENABLED=0
+WORKDIR /go/src/github.com/newrelic/nri-varnish
+COPY . .
+RUN make clean compile
+
+# We use the varnish image as a base because the nri-varnish integration executes the 
+# varnishstat command inside the varnish image to collect metrics.
+FROM varnish:6.4
+COPY --from=builder /go/src/github.com/newrelic/nri-varnish/bin /

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,3 +1,4 @@
+ARG VARNISH_TAG=6.0
 FROM golang:1.16 as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-varnish
@@ -6,5 +7,5 @@ RUN make clean compile
 
 # We use the varnish image as a base because the nri-varnish integration executes the 
 # varnishstat command inside the varnish image to collect metrics.
-FROM varnish:6.4
+FROM varnish:$VARNISH_TAG
 COPY --from=builder /go/src/github.com/newrelic/nri-varnish/bin /

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+  nri-varnish:
+    container_name: integration_nri-varnish_1
+    build:
+      context: ../../
+      dockerfile: tests/integration/Dockerfile
+    volumes:
+    - ./varnish/default.vcl:/etc/varnish/default.vcl
+    # Fake varnish params file used to test inventory collection.
+    - ../../src/testdata/varnish.params:/testdata/varnish.params

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,10 +1,25 @@
 version: '3.1'
 
 services:
-  nri-varnish:
-    container_name: integration_nri-varnish_1
+  nri-varnish-stats-v0:
+    container_name: varnish-stats-v0
     build:
       context: ../../
+      args: 
+        VARNISH_TAG: "6.4"
+      dockerfile: tests/integration/Dockerfile
+    volumes:
+    - ./varnish/default.vcl:/etc/varnish/default.vcl
+    # Fake varnish params file used to test inventory collection.
+    - ../../src/testdata/varnish.params:/testdata/varnish.params
+
+  nri-varnish-stats-v1:
+    container_name: varnish-stats-v1
+    build:
+      context: ../../
+      args: 
+        # Varnish 6.5 introduces new stats schema version 1 https://varnish-cache.org/docs/6.5/whats-new/upgrading-6.5.html#varnishstat
+        VARNISH_TAG: "6.6"
       dockerfile: tests/integration/Dockerfile
     volumes:
     - ./varnish/default.vcl:/etc/varnish/default.vcl

--- a/tests/integration/helpers/helpers.go
+++ b/tests/integration/helpers/helpers.go
@@ -1,0 +1,71 @@
+//go:build integration
+// +build integration
+
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// Arbitrary amount of time to let tests exit cleanly before main process terminates.
+	timeoutGracePeriod = 10 * time.Second
+)
+
+// ExecInContainer executes the given command inside the specified container. It returns three values:
+// 1st - Standard Output
+// 2nd - Standard Error
+// 3rd - Runtime error, if any
+func ExecInContainer(t *testing.T, timeout time.Duration, container string, command []string, envVars ...string) (string, string) {
+	t.Helper()
+
+	cmdLine := make([]string, 0, 3+len(command))
+	cmdLine = append(cmdLine, "exec", "-i")
+
+	for _, envVar := range envVars {
+		cmdLine = append(cmdLine, "-e", envVar)
+	}
+
+	cmdLine = append(cmdLine, container)
+	cmdLine = append(cmdLine, command...)
+
+	t.Logf("executing: docker %s", strings.Join(cmdLine, " "))
+
+	ctx, _ := context.WithTimeout(contextWithDeadline(t), timeout)
+	cmd := exec.CommandContext(ctx, "docker", cmdLine...)
+
+	var outBuffer, errBuffer bytes.Buffer
+	cmd.Stdout = &outBuffer
+	cmd.Stderr = &errBuffer
+
+	if err := cmd.Run(); err != nil {
+		t.Errorf("Integration command failed to run: %s", err)
+		t.Fail()
+	}
+
+	stdout := outBuffer.String()
+	stderr := errBuffer.String()
+
+	return stdout, stderr
+}
+
+// contextWithDeadline returns context which will timeout before t.Deadline().
+func contextWithDeadline(t *testing.T) context.Context {
+	t.Helper()
+
+	deadline, ok := t.Deadline()
+	if !ok {
+		return context.Background()
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline.Truncate(timeoutGracePeriod))
+
+	t.Cleanup(cancel)
+
+	return ctx
+}

--- a/tests/integration/json-schema-files/inventory.json
+++ b/tests/integration/json-schema-files/inventory.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "protocol_version": {
+      "type": "string"
+    },
+    "integration_version": {
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "entity": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "id_attributes": {
+                  "type": "array",
+                  "items": {}
+                }
+              },
+              "required": [
+                "name",
+                "type",
+                "id_attributes"
+              ]
+            },
+            "metrics": {
+              "type": "array",
+              "items": {}
+            },
+            "inventory": {
+              "type": "object",
+              "properties": {
+                "params/RELOAD_VCL": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_ADMIN_LISTEN_ADDRESS": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_ADMIN_LISTEN_PORT": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_GROUP": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_LISTEN_PORT": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_SECRET_FILE": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_STORAGE": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_USER": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                },
+                "params/VARNISH_VCL_CONF": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "value"
+                  ]
+                }
+              },
+              "required": [
+                "params/RELOAD_VCL",
+                "params/VARNISH_ADMIN_LISTEN_ADDRESS",
+                "params/VARNISH_ADMIN_LISTEN_PORT",
+                "params/VARNISH_GROUP",
+                "params/VARNISH_LISTEN_PORT",
+                "params/VARNISH_SECRET_FILE",
+                "params/VARNISH_STORAGE",
+                "params/VARNISH_USER",
+                "params/VARNISH_VCL_CONF"
+              ]
+            },
+            "events": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "required": [
+            "entity",
+            "metrics",
+            "inventory",
+            "events"
+          ]
+        }
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "protocol_version",
+    "integration_version",
+    "data"
+  ]
+}

--- a/tests/integration/json-schema-files/metrics.json
+++ b/tests/integration/json-schema-files/metrics.json
@@ -44,94 +44,94 @@
                     "type": "object",
                     "properties": {
                       "backend.connectionBusy": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionFails": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionRecycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionRetries": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionReuses": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionSuccess": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionUnHealthy": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.fetches": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.requests": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.added": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.completed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.cutoffLurkerKilled": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.deleted": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.dups": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.fragmentationInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.lookupKilled": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.lookupTestsTested": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.lurkerCon": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.lurkerKilled": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.lurkerTested": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.lurkerTestsTested": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.obj": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.persistedInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.req": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "bans.tested": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "cache.graceHits": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "cache.hits": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "cache.missHits": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "cache.misses": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "cache.passHits": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "displayName": {
                         "type": "string"
@@ -140,334 +140,334 @@
                         "type": "string"
                       },
                       "esi.errors": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "esi.warnings": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "event_type": {
                         "type": "string"
                       },
                       "fetch.bad": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.chuncked": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.contentLength": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.eof": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.failed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.head": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.noBody": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.noBody1xx": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.noBody204": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.noBody304": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "fetch.noThreadFail": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "hcb.inserts": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "hcb.lock": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "hcb.noLock": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lru.limited": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lru.moved": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lru.nuked": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.backends": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.bans": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.busyKilled": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.busySleep": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.busyWakeup": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.expired": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.expiredMailed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.expiredReceived": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.gunzip": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.gunzipTest": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.gzip": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.objectcores": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.objectheads": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.objects": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.passedRequests": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.pipeSessions": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.pools": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.purgeObjects": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.purgeOperations": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.reqDropped": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.sessQueueLength": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.sessions": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.summs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.syntheticResponses": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.threads": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.threadsCreated": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.threadsDestroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.threadsFailed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.threadsLimited": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.unresurrectedObjects": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.uptimeInMilliseconds": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.vclAvailable": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.vclDiscarded": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.vclFails": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.vclLoaded": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "main.vmodsLoaded": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.childDied": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.childDump": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.childExit": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.childPanic": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.childStart": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.childStop": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mgt.uptimeInMilliseconds": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.400Errors": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.417Errors": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.httpOverflow": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.pipe.inInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.pipe.outInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.pipereq.headerInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.request.bodyInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.request.headerInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.requests": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.response.bodyInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.response.headerInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
                       },
                       "sess.backendClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.badClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.bodyFailClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.clientClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.clientReqClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.closed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.closedError": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.dropped": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.eofTxnClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.errorTxnClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.herd": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.junkClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.overflowClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.overloadClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.pipeOverflowClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.pipeTxnClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.queued": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.readAhead": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.requestHTTP10Close": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.requestHTTP20Close": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.shortRangeClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.timeoutClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "sess.vclFailClose": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "session.connections": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "session.fail": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "shm.contentions": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "shm.cycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "shm.flushes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "shm.records": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "shm.writes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "workspace.backendOverflow": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "workspace.clientOverflow": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "workspace.deliveryFail": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "workspace.sessionOverflow": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "workspace.threadOverflow": {
-                        "type": "integer"
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -631,13 +631,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -670,13 +670,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -709,13 +709,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -748,13 +748,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -787,13 +787,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -826,13 +826,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -865,13 +865,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -904,13 +904,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -943,13 +943,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -982,13 +982,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1021,13 +1021,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1060,13 +1060,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1099,13 +1099,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1138,13 +1138,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1177,13 +1177,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1216,13 +1216,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1255,13 +1255,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1294,13 +1294,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1333,13 +1333,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1372,13 +1372,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1411,13 +1411,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1450,13 +1450,13 @@
                         "type": "string"
                       },
                       "lock.created": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.destroyed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "lock.locks": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1489,37 +1489,37 @@
                         "type": "string"
                       },
                       "mempool.allocatedSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.allocs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.frees": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.live": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.pool": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.ranDry": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.recycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.requestSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.surplus": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.timeouts": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.tooSmall": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1560,37 +1560,37 @@
                         "type": "string"
                       },
                       "mempool.allocatedSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.allocs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.frees": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.live": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.pool": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.ranDry": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.recycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.requestSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.surplus": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.timeouts": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.tooSmall": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1631,37 +1631,37 @@
                         "type": "string"
                       },
                       "mempool.allocatedSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.allocs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.frees": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.live": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.pool": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.ranDry": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.recycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.requestSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.surplus": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.timeouts": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.tooSmall": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1702,37 +1702,37 @@
                         "type": "string"
                       },
                       "mempool.allocatedSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.allocs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.frees": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.live": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.pool": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.ranDry": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.recycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.requestSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.surplus": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.timeouts": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.tooSmall": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1773,37 +1773,37 @@
                         "type": "string"
                       },
                       "mempool.allocatedSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.allocs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.frees": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.live": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.pool": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.ranDry": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.recycles": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.requestSizeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.surplus": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.timeouts": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "mempool.tooSmall": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"
@@ -1847,25 +1847,25 @@
                         "type": "string"
                       },
                       "storage.allocFails": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.allocInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.allocOustanding": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.allocReqs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.availableInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.freeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.outstandingInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -1902,25 +1902,25 @@
                         "type": "string"
                       },
                       "storage.allocFails": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.allocInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.allocOustanding": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.allocReqs": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.availableInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.freeInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "storage.outstandingInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       }
                     },
                     "required": [
@@ -2001,22 +2001,22 @@
                     "type": "object",
                     "properties": {
                       "backend.busyFetches": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connections": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionsFailed": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.connectionsNotAttempted": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.happy": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "backend.unhealthyFetches": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "displayName": {
                         "type": "string"
@@ -2028,28 +2028,28 @@
                         "type": "string"
                       },
                       "net.backend.pipeHeaderInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.pipeInInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.pipeOutInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.requestBodyInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.requestHeaderInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.requests": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.responseBodyInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "net.backend.responseHeaderInBytes": {
-                        "type": "integer"
+                        "type": "number"
                       },
                       "reportingEntityKey": {
                         "type": "string"

--- a/tests/integration/json-schema-files/metrics.json
+++ b/tests/integration/json-schema-files/metrics.json
@@ -1,0 +1,2105 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "protocol_version": {
+        "type": "string"
+      },
+      "integration_version": {
+        "type": "string"
+      },
+      "data": {
+        "type": "array",
+        "items": [
+          {
+            "type": "object",
+            "properties": {
+              "entity": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "items": {}
+                  }
+                },
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ]
+              },
+              "metrics": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "backend.connectionBusy": {
+                        "type": "integer"
+                      },
+                      "backend.connectionFails": {
+                        "type": "integer"
+                      },
+                      "backend.connectionRecycles": {
+                        "type": "integer"
+                      },
+                      "backend.connectionRetries": {
+                        "type": "integer"
+                      },
+                      "backend.connectionReuses": {
+                        "type": "integer"
+                      },
+                      "backend.connectionSuccess": {
+                        "type": "integer"
+                      },
+                      "backend.connectionUnHealthy": {
+                        "type": "integer"
+                      },
+                      "backend.fetches": {
+                        "type": "integer"
+                      },
+                      "backend.requests": {
+                        "type": "integer"
+                      },
+                      "bans.added": {
+                        "type": "integer"
+                      },
+                      "bans.completed": {
+                        "type": "integer"
+                      },
+                      "bans.cutoffLurkerKilled": {
+                        "type": "integer"
+                      },
+                      "bans.deleted": {
+                        "type": "integer"
+                      },
+                      "bans.dups": {
+                        "type": "integer"
+                      },
+                      "bans.fragmentationInBytes": {
+                        "type": "integer"
+                      },
+                      "bans.lookupKilled": {
+                        "type": "integer"
+                      },
+                      "bans.lookupTestsTested": {
+                        "type": "integer"
+                      },
+                      "bans.lurkerCon": {
+                        "type": "integer"
+                      },
+                      "bans.lurkerKilled": {
+                        "type": "integer"
+                      },
+                      "bans.lurkerTested": {
+                        "type": "integer"
+                      },
+                      "bans.lurkerTestsTested": {
+                        "type": "integer"
+                      },
+                      "bans.obj": {
+                        "type": "integer"
+                      },
+                      "bans.persistedInBytes": {
+                        "type": "integer"
+                      },
+                      "bans.req": {
+                        "type": "integer"
+                      },
+                      "bans.tested": {
+                        "type": "integer"
+                      },
+                      "cache.graceHits": {
+                        "type": "integer"
+                      },
+                      "cache.hits": {
+                        "type": "integer"
+                      },
+                      "cache.missHits": {
+                        "type": "integer"
+                      },
+                      "cache.misses": {
+                        "type": "integer"
+                      },
+                      "cache.passHits": {
+                        "type": "integer"
+                      },
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "esi.errors": {
+                        "type": "integer"
+                      },
+                      "esi.warnings": {
+                        "type": "integer"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "fetch.bad": {
+                        "type": "integer"
+                      },
+                      "fetch.chuncked": {
+                        "type": "integer"
+                      },
+                      "fetch.contentLength": {
+                        "type": "integer"
+                      },
+                      "fetch.eof": {
+                        "type": "integer"
+                      },
+                      "fetch.failed": {
+                        "type": "integer"
+                      },
+                      "fetch.head": {
+                        "type": "integer"
+                      },
+                      "fetch.noBody": {
+                        "type": "integer"
+                      },
+                      "fetch.noBody1xx": {
+                        "type": "integer"
+                      },
+                      "fetch.noBody204": {
+                        "type": "integer"
+                      },
+                      "fetch.noBody304": {
+                        "type": "integer"
+                      },
+                      "fetch.noThreadFail": {
+                        "type": "integer"
+                      },
+                      "hcb.inserts": {
+                        "type": "integer"
+                      },
+                      "hcb.lock": {
+                        "type": "integer"
+                      },
+                      "hcb.noLock": {
+                        "type": "integer"
+                      },
+                      "lru.limited": {
+                        "type": "integer"
+                      },
+                      "lru.moved": {
+                        "type": "integer"
+                      },
+                      "lru.nuked": {
+                        "type": "integer"
+                      },
+                      "main.backends": {
+                        "type": "integer"
+                      },
+                      "main.bans": {
+                        "type": "integer"
+                      },
+                      "main.busyKilled": {
+                        "type": "integer"
+                      },
+                      "main.busySleep": {
+                        "type": "integer"
+                      },
+                      "main.busyWakeup": {
+                        "type": "integer"
+                      },
+                      "main.expired": {
+                        "type": "integer"
+                      },
+                      "main.expiredMailed": {
+                        "type": "integer"
+                      },
+                      "main.expiredReceived": {
+                        "type": "integer"
+                      },
+                      "main.gunzip": {
+                        "type": "integer"
+                      },
+                      "main.gunzipTest": {
+                        "type": "integer"
+                      },
+                      "main.gzip": {
+                        "type": "integer"
+                      },
+                      "main.objectcores": {
+                        "type": "integer"
+                      },
+                      "main.objectheads": {
+                        "type": "integer"
+                      },
+                      "main.objects": {
+                        "type": "integer"
+                      },
+                      "main.passedRequests": {
+                        "type": "integer"
+                      },
+                      "main.pipeSessions": {
+                        "type": "integer"
+                      },
+                      "main.pools": {
+                        "type": "integer"
+                      },
+                      "main.purgeObjects": {
+                        "type": "integer"
+                      },
+                      "main.purgeOperations": {
+                        "type": "integer"
+                      },
+                      "main.reqDropped": {
+                        "type": "integer"
+                      },
+                      "main.sessQueueLength": {
+                        "type": "integer"
+                      },
+                      "main.sessions": {
+                        "type": "integer"
+                      },
+                      "main.summs": {
+                        "type": "integer"
+                      },
+                      "main.syntheticResponses": {
+                        "type": "integer"
+                      },
+                      "main.threads": {
+                        "type": "integer"
+                      },
+                      "main.threadsCreated": {
+                        "type": "integer"
+                      },
+                      "main.threadsDestroyed": {
+                        "type": "integer"
+                      },
+                      "main.threadsFailed": {
+                        "type": "integer"
+                      },
+                      "main.threadsLimited": {
+                        "type": "integer"
+                      },
+                      "main.unresurrectedObjects": {
+                        "type": "integer"
+                      },
+                      "main.uptimeInMilliseconds": {
+                        "type": "integer"
+                      },
+                      "main.vclAvailable": {
+                        "type": "integer"
+                      },
+                      "main.vclDiscarded": {
+                        "type": "integer"
+                      },
+                      "main.vclFails": {
+                        "type": "integer"
+                      },
+                      "main.vclLoaded": {
+                        "type": "integer"
+                      },
+                      "main.vmodsLoaded": {
+                        "type": "integer"
+                      },
+                      "mgt.childDied": {
+                        "type": "integer"
+                      },
+                      "mgt.childDump": {
+                        "type": "integer"
+                      },
+                      "mgt.childExit": {
+                        "type": "integer"
+                      },
+                      "mgt.childPanic": {
+                        "type": "integer"
+                      },
+                      "mgt.childStart": {
+                        "type": "integer"
+                      },
+                      "mgt.childStop": {
+                        "type": "integer"
+                      },
+                      "mgt.uptimeInMilliseconds": {
+                        "type": "integer"
+                      },
+                      "net.400Errors": {
+                        "type": "integer"
+                      },
+                      "net.417Errors": {
+                        "type": "integer"
+                      },
+                      "net.httpOverflow": {
+                        "type": "integer"
+                      },
+                      "net.pipe.inInBytes": {
+                        "type": "integer"
+                      },
+                      "net.pipe.outInBytes": {
+                        "type": "integer"
+                      },
+                      "net.pipereq.headerInBytes": {
+                        "type": "integer"
+                      },
+                      "net.request.bodyInBytes": {
+                        "type": "integer"
+                      },
+                      "net.request.headerInBytes": {
+                        "type": "integer"
+                      },
+                      "net.requests": {
+                        "type": "integer"
+                      },
+                      "net.response.bodyInBytes": {
+                        "type": "integer"
+                      },
+                      "net.response.headerInBytes": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      },
+                      "sess.backendClose": {
+                        "type": "integer"
+                      },
+                      "sess.badClose": {
+                        "type": "integer"
+                      },
+                      "sess.bodyFailClose": {
+                        "type": "integer"
+                      },
+                      "sess.clientClose": {
+                        "type": "integer"
+                      },
+                      "sess.clientReqClose": {
+                        "type": "integer"
+                      },
+                      "sess.closed": {
+                        "type": "integer"
+                      },
+                      "sess.closedError": {
+                        "type": "integer"
+                      },
+                      "sess.dropped": {
+                        "type": "integer"
+                      },
+                      "sess.eofTxnClose": {
+                        "type": "integer"
+                      },
+                      "sess.errorTxnClose": {
+                        "type": "integer"
+                      },
+                      "sess.herd": {
+                        "type": "integer"
+                      },
+                      "sess.junkClose": {
+                        "type": "integer"
+                      },
+                      "sess.overflowClose": {
+                        "type": "integer"
+                      },
+                      "sess.overloadClose": {
+                        "type": "integer"
+                      },
+                      "sess.pipeOverflowClose": {
+                        "type": "integer"
+                      },
+                      "sess.pipeTxnClose": {
+                        "type": "integer"
+                      },
+                      "sess.queued": {
+                        "type": "integer"
+                      },
+                      "sess.readAhead": {
+                        "type": "integer"
+                      },
+                      "sess.requestHTTP10Close": {
+                        "type": "integer"
+                      },
+                      "sess.requestHTTP20Close": {
+                        "type": "integer"
+                      },
+                      "sess.shortRangeClose": {
+                        "type": "integer"
+                      },
+                      "sess.timeoutClose": {
+                        "type": "integer"
+                      },
+                      "sess.vclFailClose": {
+                        "type": "integer"
+                      },
+                      "session.connections": {
+                        "type": "integer"
+                      },
+                      "session.fail": {
+                        "type": "integer"
+                      },
+                      "shm.contentions": {
+                        "type": "integer"
+                      },
+                      "shm.cycles": {
+                        "type": "integer"
+                      },
+                      "shm.flushes": {
+                        "type": "integer"
+                      },
+                      "shm.records": {
+                        "type": "integer"
+                      },
+                      "shm.writes": {
+                        "type": "integer"
+                      },
+                      "workspace.backendOverflow": {
+                        "type": "integer"
+                      },
+                      "workspace.clientOverflow": {
+                        "type": "integer"
+                      },
+                      "workspace.deliveryFail": {
+                        "type": "integer"
+                      },
+                      "workspace.sessionOverflow": {
+                        "type": "integer"
+                      },
+                      "workspace.threadOverflow": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "backend.connectionBusy",
+                      "backend.connectionFails",
+                      "backend.connectionRecycles",
+                      "backend.connectionRetries",
+                      "backend.connectionReuses",
+                      "backend.connectionSuccess",
+                      "backend.connectionUnHealthy",
+                      "backend.fetches",
+                      "backend.requests",
+                      "bans.added",
+                      "bans.completed",
+                      "bans.cutoffLurkerKilled",
+                      "bans.deleted",
+                      "bans.dups",
+                      "bans.fragmentationInBytes",
+                      "bans.lookupKilled",
+                      "bans.lookupTestsTested",
+                      "bans.lurkerCon",
+                      "bans.lurkerKilled",
+                      "bans.lurkerTested",
+                      "bans.lurkerTestsTested",
+                      "bans.obj",
+                      "bans.persistedInBytes",
+                      "bans.req",
+                      "bans.tested",
+                      "cache.graceHits",
+                      "cache.hits",
+                      "cache.missHits",
+                      "cache.misses",
+                      "cache.passHits",
+                      "displayName",
+                      "entityName",
+                      "esi.errors",
+                      "esi.warnings",
+                      "event_type",
+                      "fetch.bad",
+                      "fetch.chuncked",
+                      "fetch.contentLength",
+                      "fetch.eof",
+                      "fetch.failed",
+                      "fetch.head",
+                      "fetch.noBody",
+                      "fetch.noBody1xx",
+                      "fetch.noBody204",
+                      "fetch.noBody304",
+                      "fetch.noThreadFail",
+                      "hcb.inserts",
+                      "hcb.lock",
+                      "hcb.noLock",
+                      "lru.limited",
+                      "lru.moved",
+                      "lru.nuked",
+                      "main.backends",
+                      "main.bans",
+                      "main.busyKilled",
+                      "main.busySleep",
+                      "main.busyWakeup",
+                      "main.expired",
+                      "main.expiredMailed",
+                      "main.expiredReceived",
+                      "main.gunzip",
+                      "main.gunzipTest",
+                      "main.gzip",
+                      "main.objectcores",
+                      "main.objectheads",
+                      "main.objects",
+                      "main.passedRequests",
+                      "main.pipeSessions",
+                      "main.pools",
+                      "main.purgeObjects",
+                      "main.purgeOperations",
+                      "main.reqDropped",
+                      "main.sessQueueLength",
+                      "main.sessions",
+                      "main.summs",
+                      "main.syntheticResponses",
+                      "main.threads",
+                      "main.threadsCreated",
+                      "main.threadsDestroyed",
+                      "main.threadsFailed",
+                      "main.threadsLimited",
+                      "main.unresurrectedObjects",
+                      "main.uptimeInMilliseconds",
+                      "main.vclAvailable",
+                      "main.vclDiscarded",
+                      "main.vclFails",
+                      "main.vclLoaded",
+                      "main.vmodsLoaded",
+                      "mgt.childDied",
+                      "mgt.childDump",
+                      "mgt.childExit",
+                      "mgt.childPanic",
+                      "mgt.childStart",
+                      "mgt.childStop",
+                      "mgt.uptimeInMilliseconds",
+                      "net.400Errors",
+                      "net.417Errors",
+                      "net.httpOverflow",
+                      "net.pipe.inInBytes",
+                      "net.pipe.outInBytes",
+                      "net.pipereq.headerInBytes",
+                      "net.request.bodyInBytes",
+                      "net.request.headerInBytes",
+                      "net.requests",
+                      "net.response.bodyInBytes",
+                      "net.response.headerInBytes",
+                      "reportingEntityKey",
+                      "sess.backendClose",
+                      "sess.badClose",
+                      "sess.bodyFailClose",
+                      "sess.clientClose",
+                      "sess.clientReqClose",
+                      "sess.closed",
+                      "sess.closedError",
+                      "sess.dropped",
+                      "sess.eofTxnClose",
+                      "sess.errorTxnClose",
+                      "sess.herd",
+                      "sess.junkClose",
+                      "sess.overflowClose",
+                      "sess.overloadClose",
+                      "sess.pipeOverflowClose",
+                      "sess.pipeTxnClose",
+                      "sess.queued",
+                      "sess.readAhead",
+                      "sess.requestHTTP10Close",
+                      "sess.requestHTTP20Close",
+                      "sess.shortRangeClose",
+                      "sess.timeoutClose",
+                      "sess.vclFailClose",
+                      "session.connections",
+                      "session.fail",
+                      "shm.contentions",
+                      "shm.cycles",
+                      "shm.flushes",
+                      "shm.records",
+                      "shm.writes",
+                      "workspace.backendOverflow",
+                      "workspace.clientOverflow",
+                      "workspace.deliveryFail",
+                      "workspace.sessionOverflow",
+                      "workspace.threadOverflow"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "lock": {
+                        "type": "string"
+                      },
+                      "lock.created": {
+                        "type": "integer"
+                      },
+                      "lock.destroyed": {
+                        "type": "integer"
+                      },
+                      "lock.locks": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "lock",
+                      "lock.created",
+                      "lock.destroyed",
+                      "lock.locks",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "memoryPool": {
+                        "type": "string"
+                      },
+                      "mempool.allocatedSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.allocs": {
+                        "type": "integer"
+                      },
+                      "mempool.frees": {
+                        "type": "integer"
+                      },
+                      "mempool.live": {
+                        "type": "integer"
+                      },
+                      "mempool.pool": {
+                        "type": "integer"
+                      },
+                      "mempool.ranDry": {
+                        "type": "integer"
+                      },
+                      "mempool.recycles": {
+                        "type": "integer"
+                      },
+                      "mempool.requestSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.surplus": {
+                        "type": "integer"
+                      },
+                      "mempool.timeouts": {
+                        "type": "integer"
+                      },
+                      "mempool.tooSmall": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "memoryPool",
+                      "mempool.allocatedSizeInBytes",
+                      "mempool.allocs",
+                      "mempool.frees",
+                      "mempool.live",
+                      "mempool.pool",
+                      "mempool.ranDry",
+                      "mempool.recycles",
+                      "mempool.requestSizeInBytes",
+                      "mempool.surplus",
+                      "mempool.timeouts",
+                      "mempool.tooSmall",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "memoryPool": {
+                        "type": "string"
+                      },
+                      "mempool.allocatedSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.allocs": {
+                        "type": "integer"
+                      },
+                      "mempool.frees": {
+                        "type": "integer"
+                      },
+                      "mempool.live": {
+                        "type": "integer"
+                      },
+                      "mempool.pool": {
+                        "type": "integer"
+                      },
+                      "mempool.ranDry": {
+                        "type": "integer"
+                      },
+                      "mempool.recycles": {
+                        "type": "integer"
+                      },
+                      "mempool.requestSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.surplus": {
+                        "type": "integer"
+                      },
+                      "mempool.timeouts": {
+                        "type": "integer"
+                      },
+                      "mempool.tooSmall": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "memoryPool",
+                      "mempool.allocatedSizeInBytes",
+                      "mempool.allocs",
+                      "mempool.frees",
+                      "mempool.live",
+                      "mempool.pool",
+                      "mempool.ranDry",
+                      "mempool.recycles",
+                      "mempool.requestSizeInBytes",
+                      "mempool.surplus",
+                      "mempool.timeouts",
+                      "mempool.tooSmall",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "memoryPool": {
+                        "type": "string"
+                      },
+                      "mempool.allocatedSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.allocs": {
+                        "type": "integer"
+                      },
+                      "mempool.frees": {
+                        "type": "integer"
+                      },
+                      "mempool.live": {
+                        "type": "integer"
+                      },
+                      "mempool.pool": {
+                        "type": "integer"
+                      },
+                      "mempool.ranDry": {
+                        "type": "integer"
+                      },
+                      "mempool.recycles": {
+                        "type": "integer"
+                      },
+                      "mempool.requestSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.surplus": {
+                        "type": "integer"
+                      },
+                      "mempool.timeouts": {
+                        "type": "integer"
+                      },
+                      "mempool.tooSmall": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "memoryPool",
+                      "mempool.allocatedSizeInBytes",
+                      "mempool.allocs",
+                      "mempool.frees",
+                      "mempool.live",
+                      "mempool.pool",
+                      "mempool.ranDry",
+                      "mempool.recycles",
+                      "mempool.requestSizeInBytes",
+                      "mempool.surplus",
+                      "mempool.timeouts",
+                      "mempool.tooSmall",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "memoryPool": {
+                        "type": "string"
+                      },
+                      "mempool.allocatedSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.allocs": {
+                        "type": "integer"
+                      },
+                      "mempool.frees": {
+                        "type": "integer"
+                      },
+                      "mempool.live": {
+                        "type": "integer"
+                      },
+                      "mempool.pool": {
+                        "type": "integer"
+                      },
+                      "mempool.ranDry": {
+                        "type": "integer"
+                      },
+                      "mempool.recycles": {
+                        "type": "integer"
+                      },
+                      "mempool.requestSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.surplus": {
+                        "type": "integer"
+                      },
+                      "mempool.timeouts": {
+                        "type": "integer"
+                      },
+                      "mempool.tooSmall": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "memoryPool",
+                      "mempool.allocatedSizeInBytes",
+                      "mempool.allocs",
+                      "mempool.frees",
+                      "mempool.live",
+                      "mempool.pool",
+                      "mempool.ranDry",
+                      "mempool.recycles",
+                      "mempool.requestSizeInBytes",
+                      "mempool.surplus",
+                      "mempool.timeouts",
+                      "mempool.tooSmall",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "memoryPool": {
+                        "type": "string"
+                      },
+                      "mempool.allocatedSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.allocs": {
+                        "type": "integer"
+                      },
+                      "mempool.frees": {
+                        "type": "integer"
+                      },
+                      "mempool.live": {
+                        "type": "integer"
+                      },
+                      "mempool.pool": {
+                        "type": "integer"
+                      },
+                      "mempool.ranDry": {
+                        "type": "integer"
+                      },
+                      "mempool.recycles": {
+                        "type": "integer"
+                      },
+                      "mempool.requestSizeInBytes": {
+                        "type": "integer"
+                      },
+                      "mempool.surplus": {
+                        "type": "integer"
+                      },
+                      "mempool.timeouts": {
+                        "type": "integer"
+                      },
+                      "mempool.tooSmall": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "memoryPool",
+                      "mempool.allocatedSizeInBytes",
+                      "mempool.allocs",
+                      "mempool.frees",
+                      "mempool.live",
+                      "mempool.pool",
+                      "mempool.ranDry",
+                      "mempool.recycles",
+                      "mempool.requestSizeInBytes",
+                      "mempool.surplus",
+                      "mempool.timeouts",
+                      "mempool.tooSmall",
+                      "reportingEntityKey"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      },
+                      "storage": {
+                        "type": "string"
+                      },
+                      "storage.allocFails": {
+                        "type": "integer"
+                      },
+                      "storage.allocInBytes": {
+                        "type": "integer"
+                      },
+                      "storage.allocOustanding": {
+                        "type": "integer"
+                      },
+                      "storage.allocReqs": {
+                        "type": "integer"
+                      },
+                      "storage.availableInBytes": {
+                        "type": "integer"
+                      },
+                      "storage.freeInBytes": {
+                        "type": "integer"
+                      },
+                      "storage.outstandingInBytes": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "reportingEntityKey",
+                      "storage",
+                      "storage.allocFails",
+                      "storage.allocInBytes",
+                      "storage.allocOustanding",
+                      "storage.allocReqs",
+                      "storage.availableInBytes",
+                      "storage.freeInBytes",
+                      "storage.outstandingInBytes"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      },
+                      "storage": {
+                        "type": "string"
+                      },
+                      "storage.allocFails": {
+                        "type": "integer"
+                      },
+                      "storage.allocInBytes": {
+                        "type": "integer"
+                      },
+                      "storage.allocOustanding": {
+                        "type": "integer"
+                      },
+                      "storage.allocReqs": {
+                        "type": "integer"
+                      },
+                      "storage.availableInBytes": {
+                        "type": "integer"
+                      },
+                      "storage.freeInBytes": {
+                        "type": "integer"
+                      },
+                      "storage.outstandingInBytes": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "reportingEntityKey",
+                      "storage",
+                      "storage.allocFails",
+                      "storage.allocInBytes",
+                      "storage.allocOustanding",
+                      "storage.allocReqs",
+                      "storage.availableInBytes",
+                      "storage.freeInBytes",
+                      "storage.outstandingInBytes"
+                    ]
+                  }
+                ]
+              },
+              "inventory": {
+                "type": "object"
+              },
+              "events": {
+                "type": "array",
+                "items": {}
+              }
+            },
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "entity": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "id_attributes": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "Key": {
+                            "type": "string"
+                          },
+                          "Value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "Key",
+                          "Value"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type",
+                  "id_attributes"
+                ]
+              },
+              "metrics": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "backend.busyFetches": {
+                        "type": "integer"
+                      },
+                      "backend.connections": {
+                        "type": "integer"
+                      },
+                      "backend.connectionsFailed": {
+                        "type": "integer"
+                      },
+                      "backend.connectionsNotAttempted": {
+                        "type": "integer"
+                      },
+                      "backend.happy": {
+                        "type": "integer"
+                      },
+                      "backend.unhealthyFetches": {
+                        "type": "integer"
+                      },
+                      "displayName": {
+                        "type": "string"
+                      },
+                      "entityName": {
+                        "type": "string"
+                      },
+                      "event_type": {
+                        "type": "string"
+                      },
+                      "net.backend.pipeHeaderInBytes": {
+                        "type": "integer"
+                      },
+                      "net.backend.pipeInInBytes": {
+                        "type": "integer"
+                      },
+                      "net.backend.pipeOutInBytes": {
+                        "type": "integer"
+                      },
+                      "net.backend.requestBodyInBytes": {
+                        "type": "integer"
+                      },
+                      "net.backend.requestHeaderInBytes": {
+                        "type": "integer"
+                      },
+                      "net.backend.requests": {
+                        "type": "integer"
+                      },
+                      "net.backend.responseBodyInBytes": {
+                        "type": "integer"
+                      },
+                      "net.backend.responseHeaderInBytes": {
+                        "type": "integer"
+                      },
+                      "reportingEntityKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "backend.busyFetches",
+                      "backend.connections",
+                      "backend.connectionsFailed",
+                      "backend.connectionsNotAttempted",
+                      "backend.happy",
+                      "backend.unhealthyFetches",
+                      "displayName",
+                      "entityName",
+                      "event_type",
+                      "net.backend.pipeHeaderInBytes",
+                      "net.backend.pipeInInBytes",
+                      "net.backend.pipeOutInBytes",
+                      "net.backend.requestBodyInBytes",
+                      "net.backend.requestHeaderInBytes",
+                      "net.backend.requests",
+                      "net.backend.responseBodyInBytes",
+                      "net.backend.responseHeaderInBytes",
+                      "reportingEntityKey"
+                    ]
+                  }
+                ]
+              },
+              "inventory": {
+                "type": "object"
+              },
+              "events": {
+                "type": "array",
+                "items": {}
+              }
+            },
+            "required": [
+              "entity",
+              "metrics",
+              "inventory",
+              "events"
+            ]
+          }
+        ]
+      }
+    },
+    "required": [
+      "name",
+      "protocol_version",
+      "integration_version",
+      "data"
+    ]
+  }

--- a/tests/integration/jsonschema/jsonschema.go
+++ b/tests/integration/jsonschema/jsonschema.go
@@ -1,0 +1,48 @@
+//go:build integration
+// +build integration
+
+package jsonschema
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// Validate validates the input argument against JSON schema. If the
+// input is not valid the error is returned. The first argument is the file name
+// of the JSON schema. It is used to build file URI required to load the JSON schema.
+// The second argument is the input string that is validated.
+func Validate(t *testing.T, fileName string, input string) {
+	t.Helper()
+	t.Logf("Integration stdout: %s", input)
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	schemaURI := fmt.Sprintf("file://%s", filepath.Join(pwd, fileName))
+
+	schemaLoader := gojsonschema.NewReferenceLoader(schemaURI)
+	documentLoader := gojsonschema.NewStringLoader(input)
+
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		t.Errorf("Error loading JSON schema, error: %v", err)
+		t.Fail()
+	}
+
+	if !result.Valid() {
+		t.Errorf("Errors for JSON schema: '%s'\n", schemaURI)
+		for _, desc := range result.Errors() {
+			t.Errorf("\t- %s\n", desc)
+		}
+
+		t.Errorf("The output of the integration doesn't have expected JSON format")
+		t.Fail()
+	}
+}

--- a/tests/integration/varnish/default.vcl
+++ b/tests/integration/varnish/default.vcl
@@ -1,0 +1,5 @@
+vcl 4.0;
+
+backend default {
+  .host = "localhost:80";
+}

--- a/tests/integration/varnish_test.go
+++ b/tests/integration/varnish_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/newrelic/nri-varnish/tests/integration/helpers"
+	"github.com/newrelic/nri-varnish/tests/integration/jsonschema"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defaultContainer     = "integration_nri-varnish_1"
+	defaultBinPath       = "/nri-varnish"
+	schemasPath          = "json-schema-files"
+	metricSchemasFile    = "metrics.json"
+	inventorySchemasFile = "inventory.json"
+)
+
+// Returns the standard output, or fails testing if the command returned an error
+func runIntegration(t *testing.T, envVars ...string) (string, string) {
+	t.Helper()
+
+	command := make([]string, 0)
+	command = append(command, defaultBinPath)
+
+	timeout := 10 * time.Second
+
+	stdout, stderr := helpers.ExecInContainer(t, timeout, defaultContainer, command, envVars...)
+
+	if stderr != "" {
+		t.Logf("Integration command Standard Error: %s", stderr)
+	}
+
+	return stdout, stderr
+}
+
+func Test_integration_collects_metrics(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := runIntegration(t, "INSTANCE_NAME=test", "METRICS=true")
+	assert.Empty(t, stderr)
+
+	varnishSchemaPath := filepath.Join(schemasPath, metricSchemasFile)
+	jsonschema.Validate(t, varnishSchemaPath, stdout)
+}
+
+func Test_integration_collects_inventory(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := runIntegration(t, "INSTANCE_NAME=test", "INVENTORY=true", "PARAMS_CONFIG_FILE=/testdata/varnish.params")
+	assert.Empty(t, stderr)
+
+	varnishSchemaPath := filepath.Join(schemasPath, inventorySchemasFile)
+	jsonschema.Validate(t, varnishSchemaPath, stdout)
+}
+
+func Test_integration_not_able_to_find_params(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := runIntegration(t, "INSTANCE_NAME=test")
+	assert.Contains(t, stderr, "Error parsing params file")
+
+	varnishSchemaPath := filepath.Join(schemasPath, metricSchemasFile)
+	jsonschema.Validate(t, varnishSchemaPath, stdout)
+}


### PR DESCRIPTION
Currently, if you are using nri-varnish with a Varnish 6 instance it does not record any metrics whatsoever.

This is because varnishstat has changed format. This PR implemented support for the new version key so that it can detect the old varnishstat output as well as the new version 1 varnishstat output.

I also added a test to check the format processed successfully.