### PR TITLE
Allow varnish_name option

### DIFF
--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -12,6 +12,7 @@ type ArgumentList struct {
 	sdkArgs.DefaultArgumentList
 	ParamsConfigFile string `default:"" help:"The location of the varnish.params configuration file. If omitted will search in typical install locations"`
 	InstanceName     string `default:"" help:"User defined name to identify data from this instance in New Relic"`
+	VarnishName      string `default:"" help:"Optional. Specify the varnishd working directory (see varnishd -n)"`
 	ShowVersion      bool   `default:"false" help:"Print build information and exit"`
 }
 

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -12,7 +12,7 @@ type ArgumentList struct {
 	sdkArgs.DefaultArgumentList
 	ParamsConfigFile string `default:"" help:"The location of the varnish.params configuration file. If omitted will search in typical install locations"`
 	InstanceName     string `default:"" help:"User defined name to identify data from this instance in New Relic"`
-	VarnishName      string `default:"" help:"Optional. Specify the varnishd working directory (see varnishd -n)"`
+	VarnishName      string `default:"" help:"Optional. Name used when executing 'varnishd' daemon with a custom '-n' flag"`
 	ShowVersion      bool   `default:"false" help:"Print build information and exit"`
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -5,11 +5,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	args2 "github.com/newrelic/nri-varnish/src/args"
-	metrics2 "github.com/newrelic/nri-varnish/src/metrics"
 	"os"
 	"runtime"
 	"strings"
+
+	args2 "github.com/newrelic/nri-varnish/src/args"
+	metrics2 "github.com/newrelic/nri-varnish/src/metrics"
 
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/log"
@@ -54,7 +55,7 @@ func main() {
 	log.SetupLogging(args.Verbose)
 
 	// validate arguments
-	if err := args.Validate(); err != nil {
+	if err = args.Validate(); err != nil {
 		log.Error("Error input validation failure: %s", err.Error())
 		os.Exit(1)
 	}
@@ -71,7 +72,7 @@ func main() {
 	}
 
 	if args.HasMetrics() {
-		if err := metrics2.CollectMetrics(systemEntity, i, args.VarnishName); err != nil {
+		if err = metrics2.CollectMetrics(systemEntity, i, args.VarnishName); err != nil {
 			log.Error("Error collecting metrics: %s", err.Error())
 			os.Exit(1)
 		}
@@ -102,7 +103,7 @@ func collectParamsFile(systemEntity *integration.Entity, argsParamLoc string) er
 		return err
 	}
 	defer func() {
-		if err := file.Close(); err != nil {
+		if err = file.Close(); err != nil {
 			log.Warn("Error closing file %s: %s", *paramsLoc, err.Error())
 		}
 	}()

--- a/src/main.go
+++ b/src/main.go
@@ -71,7 +71,7 @@ func main() {
 	}
 
 	if args.HasMetrics() {
-		if err := metrics2.CollectMetrics(systemEntity, i); err != nil {
+		if err := metrics2.CollectMetrics(systemEntity, i, args.VarnishName); err != nil {
 			log.Error("Error collecting metrics: %s", err.Error())
 			os.Exit(1)
 		}

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -171,7 +171,7 @@ func setENV(t *testing.T, envName, value string) {
 func fakeExecCommand(command string, args ...string) (cmd *exec.Cmd) {
 	cs := []string{"-test.run=TestHelperProcess", "--", command}
 	cs = append(cs, args...)
-	cmd = exec.Command(os.Args[0], cs...)
+	cmd = exec.Command(os.Args[0], cs...) //nolint:gosec
 	return cmd
 }
 

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -28,7 +28,7 @@ func TestCollectMetrics(t *testing.T) {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
 
-	if err := CollectMetrics(systemEntity, i); err != nil {
+	if err := CollectMetrics(systemEntity, i, ""); err != nil {
 		t.Fatalf("Unexpected error: %s", err.Error())
 	}
 
@@ -157,7 +157,7 @@ func TestCollectMetrics_ExecError(t *testing.T) {
 		t.Fatalf("Unexpected error %s", err.Error())
 	}
 
-	if err := CollectMetrics(systemEntity, i); err == nil {
+	if err := CollectMetrics(systemEntity, i, ""); err == nil {
 		t.Error("Expected error")
 	}
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -15,8 +15,14 @@ import (
 var ExecCommand = exec.Command
 
 // CollectMetrics collects metrics from varnishstat command
-func CollectMetrics(systemEntity *integration.Entity, i *integration.Integration) error {
-	statOutput, err := ExecCommand("varnishstat", "-j").Output()
+func CollectMetrics(systemEntity *integration.Entity, i *integration.Integration, VarnishName string) error {
+	var argList = []string{"-j"}
+
+	if VarnishName != "" {
+		argList = append(argList, "-n", VarnishName)
+	}
+
+	statOutput, err := ExecCommand("varnishstat", argList...).Output()
 	if err != nil {
 		log.Debug("Error running varnishstat command: %s", err.Error())
 		return err

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -15,11 +15,11 @@ import (
 var ExecCommand = exec.Command
 
 // CollectMetrics collects metrics from varnishstat command
-func CollectMetrics(systemEntity *integration.Entity, i *integration.Integration, VarnishName string) error {
-	var argList = []string{"-j"}
+func CollectMetrics(systemEntity *integration.Entity, i *integration.Integration, varnishName string) error {
+	argList := []string{"-j"}
 
-	if VarnishName != "" {
-		argList = append(argList, "-n", VarnishName)
+	if varnishName != "" {
+		argList = append(argList, "-n", varnishName)
 	}
 
 	statOutput, err := ExecCommand("varnishstat", argList...).Output()

--- a/src/metrics/stat_parse.go
+++ b/src/metrics/stat_parse.go
@@ -99,20 +99,33 @@ func getStatValue(stat interface{}) (interface{}, error) {
 }
 
 func parseAndSetStat(varnishSystem *varnishDefinition, fullStatName string, statValue interface{}) {
-	// Parse out into structs
-	if strings.HasPrefix(fullStatName, "LCK.") {
+	prefix := splitPrefix(fullStatName, ".")
+	switch prefix {
+	case "LCK":
 		// locks
 		setLockValue(varnishSystem.locks, fullStatName, statValue)
-	} else if strings.HasPrefix(fullStatName, "SMF.") || strings.HasPrefix(fullStatName, "SMU.") || strings.HasPrefix(fullStatName, "SMA.") {
+	case "SMF", "SMU", "SMA":
 		// storage
 		setStorageValue(varnishSystem.storages, fullStatName, statValue)
-	} else if strings.HasPrefix(fullStatName, "MEMPOOL.") {
+	case "MEMPOOL":
 		// mempools
 		setMempoolValue(varnishSystem.mempools, fullStatName, statValue)
-	} else {
+	default:
 		// main sample
 		setSystemValue(varnishSystem, fullStatName, statValue)
 	}
+}
+
+// splitPrefix returns the substring of s before the sep without including it.
+// If sep does not exist it returns the empty string.
+func splitPrefix(s string, sep string) string {
+	const maxSliceSize = 2 // Just need one element for the prefix and other for the rest of the string.
+	prefixArray := strings.SplitN(s, sep, maxSliceSize)
+	if len(prefixArray) == 0 || len(prefixArray) == 1 {
+		return ""
+	}
+
+	return prefixArray[0]
 }
 
 // The following setXValue functions are just repeated code but due to Go not having generics it's

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -474,3 +474,38 @@ func Test_setValue_NoField(t *testing.T) {
 		t.Error("Expected error")
 	}
 }
+
+func Test_prefix(t *testing.T) {
+	testCases := []struct {
+		name   string
+		intput string
+		output string
+	}{
+		{
+			"string with prefix",
+			"Foo.bar",
+			"Foo",
+		},
+		{
+			"string with multiple prefix",
+			"Foo.bar.baz",
+			"Foo",
+		},
+		{
+			"string without prefix",
+			"Foobar",
+			"",
+		},
+		{
+			"string with prefix without chars",
+			".Foobar",
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		if out := splitPrefix(tc.intput, "."); out != tc.output {
+			t.Errorf("Test Case %s Failed: output: '%s' ,didn't match expected one: '%s'", tc.name, out, tc.output)
+		}
+	}
+}

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -25,3 +25,14 @@ services:
     - ./varnish/default.vcl:/etc/varnish/default.vcl
     # Fake varnish params file used to test inventory collection.
     - ../../src/testdata/varnish.params:/testdata/varnish.params
+
+  nri-varnish-named-instance:
+    container_name: varnish-named-instance
+    build:
+      context: ../../
+      args: 
+        VARNISH_TAG: "6.6"
+      dockerfile: tests/integration/Dockerfile
+    volumes:
+    - ./varnish/default.vcl:/etc/varnish/default.vcl
+    command: ["-n","customInstanceName"]

--- a/tests/integration/helpers/helpers.go
+++ b/tests/integration/helpers/helpers.go
@@ -21,7 +21,7 @@ const (
 // 1st - Standard Output
 // 2nd - Standard Error
 // 3rd - Runtime error, if any
-func ExecInContainer(t *testing.T, timeout time.Duration, container string, command []string, envVars ...string) (string, string) {
+func ExecInContainer(t *testing.T, timeout time.Duration, container string, command []string, envVars ...string) (string, string, error) {
 	t.Helper()
 
 	cmdLine := make([]string, 0, 3+len(command))
@@ -43,15 +43,12 @@ func ExecInContainer(t *testing.T, timeout time.Duration, container string, comm
 	cmd.Stdout = &outBuffer
 	cmd.Stderr = &errBuffer
 
-	if err := cmd.Run(); err != nil {
-		t.Errorf("Integration command failed to run: %s", err)
-		t.Fail()
-	}
+	err := cmd.Run()
 
 	stdout := outBuffer.String()
 	stderr := errBuffer.String()
 
-	return stdout, stderr
+	return stdout, stderr, err
 }
 
 // contextWithDeadline returns context which will timeout before t.Deadline().

--- a/tests/integration/varnish_test.go
+++ b/tests/integration/varnish_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 const (
-	varnishStatsV0       = "varnish-stats-v0"
-	varnishStatsV1       = "varnish-stats-v1"
-	defaultBinPath       = "/nri-varnish"
-	schemasPath          = "json-schema-files"
-	metricSchemasFile    = "metrics.json"
-	inventorySchemasFile = "inventory.json"
+	varnishStatsV0                = "varnish-stats-v0"
+	varnishStatsV1                = "varnish-stats-v1"
+	varnishStatsNamedInstance     = "varnish-named-instance"
+	varnishStatsNamedInstanceName = "customInstanceName" // name defined in the container commands
+	defaultBinPath                = "/nri-varnish"
+	schemasPath                   = "json-schema-files"
+	metricSchemasFile             = "metrics.json"
+	inventorySchemasFile          = "inventory.json"
 )
 
 func Test_integration_test(t *testing.T) {
@@ -47,8 +49,8 @@ func Test_integration_test(t *testing.T) {
 	for _, tc := range testCases {
 		tc.envs = append(tc.envs, "INSTANCE_NAME=test")
 		for _, container := range containers {
-			stdout, stderr := runIntegration(t, container, tc.envs...)
-			assert.Empty(t, stderr)
+			stdout, _, err := runIntegration(t, container, tc.envs...)
+			assert.NoError(t, err)
 
 			varnishSchemaPath := filepath.Join(schemasPath, tc.schemaFile)
 			jsonschema.Validate(t, varnishSchemaPath, stdout)
@@ -59,12 +61,48 @@ func Test_integration_test(t *testing.T) {
 func Test_integration_not_able_to_find_params(t *testing.T) {
 	t.Parallel()
 
-	_, stderr := runIntegration(t, varnishStatsV0, "INSTANCE_NAME=test", "INVENTORY=true")
+	_, stderr, err := runIntegration(t, varnishStatsV0, "INSTANCE_NAME=test", "INVENTORY=true")
+	assert.NoError(t, err)
 	assert.Contains(t, stderr, "Error parsing params file")
 }
 
+func Test_named_instance(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		envs []string
+		fail bool
+	}{
+		{
+			"metric collection fails without defined instance name",
+			[]string{"METRICS=true"},
+			true,
+		},
+		{
+			"metric collection works with defined instance name",
+			[]string{"METRICS=true", "VARNISH_NAME=" + varnishStatsNamedInstanceName},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.envs = append(tc.envs, "INSTANCE_NAME=test")
+
+		stdout, _, err := runIntegration(t, varnishStatsNamedInstance, tc.envs...)
+		if tc.fail {
+			assert.Error(t, err)
+			continue
+		}
+
+		assert.NoError(t, err)
+		varnishSchemaPath := filepath.Join(schemasPath, metricSchemasFile)
+		jsonschema.Validate(t, varnishSchemaPath, stdout)
+	}
+}
+
 // Returns the standard output, or fails testing if the command returned an error
-func runIntegration(t *testing.T, container string, envVars ...string) (string, string) {
+func runIntegration(t *testing.T, container string, envVars ...string) (string, string, error) {
 	t.Helper()
 
 	command := make([]string, 0)
@@ -72,11 +110,11 @@ func runIntegration(t *testing.T, container string, envVars ...string) (string, 
 
 	timeout := 10 * time.Second
 
-	stdout, stderr := helpers.ExecInContainer(t, timeout, container, command, envVars...)
+	stdout, stderr, err := helpers.ExecInContainer(t, timeout, container, command, envVars...)
 
 	if stderr != "" {
 		t.Logf("Integration command Standard Error: %s", stderr)
 	}
 
-	return stdout, stderr
+	return stdout, stderr, err
 }

--- a/varnish-config.yml.sample
+++ b/varnish-config.yml.sample
@@ -6,6 +6,8 @@ integrations:
 
     PARAMS_CONFIG_FILE: <The location of the varnish.params configuration file. If omitted will look in /etc/default/varnish/varnish.params and /etc/sysconfig/varnish/varnish.params>
 
+    VARNISH_NAME: <Optional. Specify the varnishd working directory (see varnishd -n)>
+
   interval: 15s
   labels:
     env: production

--- a/varnish-config.yml.sample
+++ b/varnish-config.yml.sample
@@ -6,7 +6,7 @@ integrations:
 
     PARAMS_CONFIG_FILE: <The location of the varnish.params configuration file. If omitted will look in /etc/default/varnish/varnish.params and /etc/sysconfig/varnish/varnish.params>
 
-    VARNISH_NAME: <Optional. Specify the varnishd working directory (see varnishd -n)>
+    VARNISH_NAME: <Optional. Name used when executing 'varnishd' daemon with a custom '-n' flag>
 
   interval: 15s
   labels:


### PR DESCRIPTION
Allows us to pass the varnish instance name as an argument to `varnishstats` re https://github.com/newrelic/nri-varnish/issues/32
The use case is for when we are running varnish with the -n option, eg `varnishd -n my_varnish_name`
Option is added to the config file, under arguments.
```
...
      instance_name: <User defined name to identify data from this instance in New Relic>
      varnish_name: <Optional. Specify the varnishd working directory (see varnishd -n)>
...
```

If omitted, `varnishstats` will continue to use the default varnish instance.