### PR TITLE
Varnish Plus attributes monitoring

### DIFF
--- a/src/metrics/metric_definitions.go
+++ b/src/metrics/metric_definitions.go
@@ -183,9 +183,11 @@ type mempoolDefinition struct {
 	RanDry        interface{} `stat_name:"randry" metric_name:"mempool.ranDry" source_type:"Rate"`
 }
 
+// bookDefinition represents the data for a VarnishBookSample event
 type bookDefinition struct {
 	Alloc        interface{} `stat_name:"g_bytes" metric_name:"book.allocInBytes" source_type:"Gauge"`
 	Available    interface{} `stat_name:"g_space" metric_name:"book.availableInBytes" source_type:"Gauge"`
+	ThreadQueued interface{} `stat_name:"c_waterlevel_queue" metric_name:"book.threadQueued" source_type:"Rate"`
 	PurgeObjects interface{} `stat_name:"c_waterlevel_purge" metric_name:"book.purgeObjects" source_type:"Rate"`
 }
 

--- a/src/metrics/metric_definitions.go
+++ b/src/metrics/metric_definitions.go
@@ -156,7 +156,7 @@ type varnishDefinition struct {
 	locks    map[string]*lockDefinition
 	mempools map[string]*mempoolDefinition
 	storages map[string]*storageDefinition
-	book	 map[string]*bookDefinition
+	book     map[string]*bookDefinition
 }
 
 // lockDefinition represents the data for a VarnishLockSample event
@@ -184,9 +184,9 @@ type mempoolDefinition struct {
 }
 
 type bookDefinition struct {
-	Alloc           interface{} `stat_name:"g_bytes" metric_name:"book.allocInBytes" source_type:"Gauge"`
-	Available       interface{} `stat_name:"g_space" metric_name:"book.availableInBytes" source_type:"Gauge"`
-	PurgeObjects	interface{} `stat_name:"c_waterlevel_purge" metric_name:"book.purgeObjects" source_type:"Rate"`
+	Alloc        interface{} `stat_name:"g_bytes" metric_name:"book.allocInBytes" source_type:"Gauge"`
+	Available    interface{} `stat_name:"g_space" metric_name:"book.availableInBytes" source_type:"Gauge"`
+	PurgeObjects interface{} `stat_name:"c_waterlevel_purge" metric_name:"book.purgeObjects" source_type:"Rate"`
 }
 
 // storageDefinition represents the data for a VarnishStorageSample event

--- a/src/metrics/metric_definitions.go
+++ b/src/metrics/metric_definitions.go
@@ -156,6 +156,7 @@ type varnishDefinition struct {
 	locks    map[string]*lockDefinition
 	mempools map[string]*mempoolDefinition
 	storages map[string]*storageDefinition
+	book	 map[string]*bookDefinition
 }
 
 // lockDefinition represents the data for a VarnishLockSample event
@@ -180,6 +181,10 @@ type mempoolDefinition struct {
 	TooSmall      interface{} `stat_name:"toosmall" metric_name:"mempool.tooSmall" source_type:"Rate"`
 	Surplus       interface{} `stat_name:"surplus" metric_name:"mempool.surplus" source_type:"Rate"`
 	RanDry        interface{} `stat_name:"randry" metric_name:"mempool.ranDry" source_type:"Rate"`
+}
+
+type bookDefinition struct {
+	Alloc           interface{} `stat_name:"g_bytes" metric_name:"book.allocInBytes" source_type:"Gauge"`
 }
 
 // storageDefinition represents the data for a VarnishStorageSample event

--- a/src/metrics/metric_definitions.go
+++ b/src/metrics/metric_definitions.go
@@ -157,6 +157,7 @@ type varnishDefinition struct {
 	mempools map[string]*mempoolDefinition
 	storages map[string]*storageDefinition
 	book     map[string]*bookDefinition
+	store	 map[string]*storeDefinition
 }
 
 // lockDefinition represents the data for a VarnishLockSample event
@@ -189,6 +190,18 @@ type bookDefinition struct {
 	Available    interface{} `stat_name:"g_space" metric_name:"book.availableInBytes" source_type:"Gauge"`
 	ThreadQueued interface{} `stat_name:"c_waterlevel_queue" metric_name:"book.threadQueued" source_type:"Rate"`
 	PurgeObjects interface{} `stat_name:"c_waterlevel_purge" metric_name:"book.purgeObjects" source_type:"Rate"`
+}
+
+type storeDefinition struct {
+	Objects 	 interface{} `stat_name:"g_objects" metric_name:"store.numOfObjects" source_type:"Gauge"`
+	AioQueue 	 interface{} `stat_name:"c_aio_queue" metric_name:"store.numOfAioQueue" source_type:"Rate"`
+	AioBytes 	 interface{} `stat_name:"c_aio_finished_bytes" metric_name:"store.numOfAioBytes" source_type:"Rate"`
+	AioRead 	 interface{} `stat_name:"c_aio_finished_read" metric_name:"store.numOfAioRead" source_type:"Rate"`
+	AioWrite 	 interface{} `stat_name:"c_aio_finished_write" metric_name:"store.numOfAioWrite" source_type:"Rate"`
+	ThreadQueue  interface{} `stat_name:"c_waterlevel_queue" metric_name:"store.threadQueue" source_type:"Rate"`
+	PurgeObjects interface{} `stat_name:"c_waterlevel_purge" metric_name:"store.purgeObjects" source_type:"Rate"`
+	YkeysReg	 interface{} `stat_name:"g_ykey_keys" metric_name:"store.numOfYkeysReg" source_type:"Gauge"`
+	YkeysPurged	 interface{} `stat_name:"c_ykey_purged" metric_name:"store.numOfYkeysPurged" source_type:"Rate"`
 }
 
 // storageDefinition represents the data for a VarnishStorageSample event

--- a/src/metrics/metric_definitions.go
+++ b/src/metrics/metric_definitions.go
@@ -185,6 +185,8 @@ type mempoolDefinition struct {
 
 type bookDefinition struct {
 	Alloc           interface{} `stat_name:"g_bytes" metric_name:"book.allocInBytes" source_type:"Gauge"`
+	Available       interface{} `stat_name:"g_space" metric_name:"book.availableInBytes" source_type:"Gauge"`
+	PurgeObjects	interface{} `stat_name:"c_waterlevel_purge" metric_name:"book.purgeObjects" source_type:"Rate"`
 }
 
 // storageDefinition represents the data for a VarnishStorageSample event

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -82,13 +82,13 @@ func TestCollectMetrics(t *testing.T) {
 			"mempool.ranDry":               float64(0),
 		},
 		{ // book
-			"displayName":              	systemEntity.Metadata.Name,
-			"entityName":               	systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
-			"event_type":               	"VarnishBookSample",
-			"book":							"book1",
-			"book.allocInBytes": 			float64(3189825536),
-			"book.availableInBytes": 		float64(2178883584),
-			"book.purgeObjects": 			float64(0),
+			"displayName":           systemEntity.Metadata.Name,
+			"entityName":            systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
+			"event_type":            "VarnishBookSample",
+			"book":                  "book1",
+			"book.allocInBytes":     float64(3189825536),
+			"book.availableInBytes": float64(2178883584),
+			"book.purgeObjects":     float64(0),
 		},
 	}
 
@@ -127,7 +127,7 @@ func TestCollectMetrics(t *testing.T) {
 		"net.backend.pipeInInBytes":         float64(0),
 		"backend.connections":               float64(0),
 		"net.backend.requests":              float64(0),
-		"backend.unhealthyFetches": 		 float64(0),
+		"backend.unhealthyFetches":          float64(0),
 	}
 
 	backendResult := backendEntity.Metrics[0].Metrics

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -81,6 +81,13 @@ func TestCollectMetrics(t *testing.T) {
 			"mempool.surplus":              float64(0),
 			"mempool.ranDry":               float64(0),
 		},
+		{ // book
+			"displayName":              systemEntity.Metadata.Name,
+			"entityName":               systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
+			"event_type":               "VarnishBookSample",
+			"book":						"book1",
+			"book.allocInBytes": 		float64(0),
+		},
 	}
 
 	for _, set := range systemEntity.Metrics {
@@ -118,6 +125,7 @@ func TestCollectMetrics(t *testing.T) {
 		"net.backend.pipeInInBytes":         float64(0),
 		"backend.connections":               float64(0),
 		"net.backend.requests":              float64(0),
+		"backend.unhealthyFetches": 		 float64(0),
 	}
 
 	backendResult := backendEntity.Metrics[0].Metrics

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -88,6 +88,7 @@ func TestCollectMetrics(t *testing.T) {
 			"book":                  "book1",
 			"book.allocInBytes":     float64(3189825536),
 			"book.availableInBytes": float64(2178883584),
+			"book.threadQueued":	 float64(0),
 			"book.purgeObjects":     float64(0),
 		},
 	}

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -82,11 +82,13 @@ func TestCollectMetrics(t *testing.T) {
 			"mempool.ranDry":               float64(0),
 		},
 		{ // book
-			"displayName":              systemEntity.Metadata.Name,
-			"entityName":               systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
-			"event_type":               "VarnishBookSample",
-			"book":						"book1",
-			"book.allocInBytes": 		float64(3189825536),
+			"displayName":              	systemEntity.Metadata.Name,
+			"entityName":               	systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
+			"event_type":               	"VarnishBookSample",
+			"book":							"book1",
+			"book.allocInBytes": 			float64(3189825536),
+			"book.availableInBytes": 		float64(2178883584),
+			"book.purgeObjects": 			float64(0),
 		},
 	}
 

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -86,7 +86,7 @@ func TestCollectMetrics(t *testing.T) {
 			"entityName":               systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
 			"event_type":               "VarnishBookSample",
 			"book":						"book1",
-			"book.allocInBytes": 		float64(0),
+			"book.allocInBytes": 		float64(3189825536),
 		},
 	}
 

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -91,6 +91,21 @@ func TestCollectMetrics(t *testing.T) {
 			"book.threadQueued":	 float64(0),
 			"book.purgeObjects":     float64(0),
 		},
+		{ // store
+			"displayName":            systemEntity.Metadata.Name,
+			"entityName":             systemEntity.Metadata.Namespace + ":" + systemEntity.Metadata.Name,
+			"event_type":             "VarnishStoreSample",
+			"store":                  "store1",
+			"store.numOfObjects":     float64(2532177),
+			"store.numOfAioQueue":	  float64(0),
+			"store.numOfAioBytes": 	  float64(0),
+			"store.numOfAioRead":     float64(0),
+			"store.numOfAioWrite":    float64(0),
+			"store.threadQueue":      float64(0),
+			"store.purgeObjects":     float64(0),
+			"store.numOfYkeysReg": 	  float64(7661493),
+			"store.numOfYkeysPurged": float64(0),
+		},
 	}
 
 	for _, set := range systemEntity.Metrics {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -101,6 +101,13 @@ func processVarnishSystem(systemEntity *integration.Entity, varnishSystem *varni
 			log.Warn("Error setting metrics for Book %s: %s", bookName, err.Error())
 		}
 	}
+
+	// Process store samples
+	for storeName, store := range varnishSystem.store {
+		if err := processSubSample(store, "VarnishStoreSample", "store", storeName, systemEntity); err != nil {
+			log.Warn("Error setting metrics for Store %s: %s", storeName, err.Error())
+		}
+	}
 }
 
 func processSubSample(subStructure interface{}, sampleName, idAttribute, idAttributeValue string, systemEntity *integration.Entity) error {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -96,9 +96,9 @@ func processVarnishSystem(systemEntity *integration.Entity, varnishSystem *varni
 	}
 
 	// Process book samples
-	for storageName, storage := range varnishSystem.book {
-		if err := processSubSample(storage, "VarnishBookSample", "book", storageName, systemEntity); err != nil {
-			log.Warn("Error setting metrics for Book %s: %s", storageName, err.Error())
+	for bookName, book := range varnishSystem.book {
+		if err := processSubSample(book, "VarnishBookSample", "book", bookName, systemEntity); err != nil {
+			log.Warn("Error setting metrics for Book %s: %s", bookName, err.Error())
 		}
 	}
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -94,6 +94,13 @@ func processVarnishSystem(systemEntity *integration.Entity, varnishSystem *varni
 			log.Warn("Error setting metrics for Storage %s: %s", storageName, err.Error())
 		}
 	}
+
+	// Process book samples
+	for storageName, storage := range varnishSystem.book {
+		if err := processSubSample(storage, "VarnishBookSample", "book", storageName, systemEntity); err != nil {
+			log.Warn("Error setting metrics for Book %s: %s", storageName, err.Error())
+		}
+	}
 }
 
 func processSubSample(subStructure interface{}, sampleName, idAttribute, idAttributeValue string, systemEntity *integration.Entity) error {

--- a/src/metrics/stat_parse.go
+++ b/src/metrics/stat_parse.go
@@ -20,7 +20,7 @@ func parseStats(statsData []byte) (*varnishDefinition, map[string]*backendDefini
 		locks:    make(map[string]*lockDefinition),
 		mempools: make(map[string]*mempoolDefinition),
 		storages: make(map[string]*storageDefinition),
-		book:	  make(map[string]*bookDefinition),
+		book:     make(map[string]*bookDefinition),
 	}
 
 	backends := make(map[string]*backendDefinition)

--- a/src/metrics/stat_parse.go
+++ b/src/metrics/stat_parse.go
@@ -21,6 +21,7 @@ func parseStats(statsData []byte) (*varnishDefinition, map[string]*backendDefini
 		mempools: make(map[string]*mempoolDefinition),
 		storages: make(map[string]*storageDefinition),
 		book:     make(map[string]*bookDefinition),
+		store:	  make(map[string]*storeDefinition),
 	}
 
 	backends := make(map[string]*backendDefinition)
@@ -114,6 +115,9 @@ func parseAndSetStat(varnishSystem *varnishDefinition, fullStatName string, stat
 	case "MSE_BOOK":
 		// book
 		setBookValue(varnishSystem.book, fullStatName, statValue)
+	case "MSE_STORE":
+		// store
+		setStoreValue(varnishSystem.store, fullStatName, statValue)
 	default:
 		// main sample
 		setSystemValue(varnishSystem, fullStatName, statValue)
@@ -204,7 +208,20 @@ func setBookValue(bookMap map[string]*bookDefinition, fullStatName string, statV
 	}
 
 	if err := setValue(book, statName, statValue); err != nil {
-		log.Debug("Error setting metric value for stat '%s' on mempool '%s': %s", statName, bookName, err.Error())
+		log.Debug("Error setting metric value for stat '%s' on book '%s': %s", statName, bookName, err.Error())
+	}
+}
+
+func setStoreValue(storeMap map[string]*storeDefinition, fullStatName string, statValue interface{}) {
+	storeName, statName := parseStatName(fullStatName)
+	store, ok := storeMap[storeName]
+	if !ok {
+		store = new(storeDefinition)
+		storeMap[storeName] = store
+	}
+
+	if err := setValue(store, statName, statValue); err != nil {
+		log.Debug("Error setting metric value for stat '%s' on store '%s': %s", statName, storeName, err.Error())
 	}
 }
 

--- a/src/metrics/stat_parse.go
+++ b/src/metrics/stat_parse.go
@@ -20,6 +20,7 @@ func parseStats(statsData []byte) (*varnishDefinition, map[string]*backendDefini
 		locks:    make(map[string]*lockDefinition),
 		mempools: make(map[string]*mempoolDefinition),
 		storages: make(map[string]*storageDefinition),
+		book:	  make(map[string]*bookDefinition),
 	}
 
 	backends := make(map[string]*backendDefinition)
@@ -110,6 +111,9 @@ func parseAndSetStat(varnishSystem *varnishDefinition, fullStatName string, stat
 	case "MEMPOOL":
 		// mempools
 		setMempoolValue(varnishSystem.mempools, fullStatName, statValue)
+	case "MSE_BOOK":
+		// book
+		setBookValue(varnishSystem.book, fullStatName, statValue)
 	default:
 		// main sample
 		setSystemValue(varnishSystem, fullStatName, statValue)
@@ -188,6 +192,19 @@ func setMempoolValue(mempoolMap map[string]*mempoolDefinition, fullStatName stri
 
 	if err := setValue(mempool, statName, statValue); err != nil {
 		log.Debug("Error setting metric value for stat '%s' on mempool '%s': %s", statName, mempoolName, err.Error())
+	}
+}
+
+func setBookValue(bookMap map[string]*bookDefinition, fullStatName string, statValue interface{}) {
+	bookName, statName := parseStatName(fullStatName)
+	book, ok := bookMap[bookName]
+	if !ok {
+		book = new(bookDefinition)
+		bookMap[bookName] = book
+	}
+
+	if err := setValue(book, statName, statValue); err != nil {
+		log.Debug("Error setting metric value for stat '%s' on mempool '%s': %s", statName, bookName, err.Error())
 	}
 }
 

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -449,6 +449,7 @@ func Test_parseStats_FullV1(t *testing.T) {
 				Pool: float64(10),
 			},
 		},
+		book: map[string]*bookDefinition{},
 	}
 
 	expectedBackends := map[string]*backendDefinition{

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -201,6 +201,51 @@ const varnishStatTestResult = `{
 		"description": "Number of objects purged to achieve database waterlevel",
 		"flag": "c", "format": "i",
 		"value": 106000
+	},
+	"MSE_STORE.store1.g_objects": {
+		"description": "Number of objects in the store",
+		"flag": "g", "format": "i",
+		"value": 2532177
+	},
+	"MSE_STORE.store1.c_aio_queue": {
+		"description": "Number of times a thread has been queued for AIO",
+		"flag": "c", "format": "i",
+		"value": 1
+	},
+	"MSE_STORE.store1.c_aio_finished_bytes": {
+		"description": "Number AIO bytes executed",
+		"flag": "c", "format": "B",
+		"value": 179596279808
+	},
+	"MSE_STORE.store1.c_aio_finished_read": {
+		"description": "Number AIO read operations executed",
+		"flag": "c", "format": "i",
+		"value": 2591278
+	},
+	"MSE_STORE.store1.c_aio_finished_write": {
+		"description": "Number AIO write operations executed",
+		"flag": "c", "format": "i",
+		"value": 22320642
+	},
+	"MSE_STORE.store1.c_waterlevel_queue": {
+		"description": "Number of times a thread has been queued waiting for store space",
+		"flag": "c", "format": "i",
+		"value": 4
+	},
+	"MSE_STORE.store1.c_waterlevel_purge": {
+		"description": "Number of objects purged to achieve store waterlevel",
+		"flag": "c", "format": "i",
+		"value": 5
+	},
+	"MSE_STORE.store1.g_ykey_keys": {
+		"description": "Number of YKeys registered",
+		"flag": "g", "format": "i",
+		"value": 7661493
+	},
+	"MSE_STORE.store1.c_ykey_purged": {
+		"description": "Number of objects purged with YKey",
+		"flag": "c", "format": "i",
+		"value": 2250426
 	}
 }`
 
@@ -249,6 +294,19 @@ func Test_parseStats_Full(t *testing.T) {
 				Available:    float64(2178883584),
 				ThreadQueued: float64(2),
 				PurgeObjects: float64(106000),
+			},
+		},
+		store: map[string]*storeDefinition{
+			"store1": {
+				Objects:  	  float64(2532177),
+				AioQueue: 	  float64(1),
+				AioBytes: 	  float64(179596279808),
+				AioRead:  	  float64(2591278),
+				AioWrite: 	  float64(22320642),
+				ThreadQueue:  float64(4),
+				PurgeObjects: float64(5),
+				YkeysReg: 	  float64(7661493),
+				YkeysPurged:  float64(2250426),
 			},
 		},
 	}
@@ -450,6 +508,7 @@ func Test_parseStats_FullV1(t *testing.T) {
 			},
 		},
 		book: map[string]*bookDefinition{},
+		store: map[string]*storeDefinition{},
 	}
 
 	expectedBackends := map[string]*backendDefinition{

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -176,6 +176,16 @@ const varnishStatTestResult = `{
 		"description": "Backend requests sent",
 		"flag": "c", "format": "i",
 		"value": 1
+	},
+	"VBE.boot.web1.unhealthy": {
+		"description": "Backend requests sent",
+		"flag": "c", "format": "i",
+		"value": 1
+	},
+	"MSE_BOOK.book1.g_bytes": {
+		"description": "Number of bytes used in the book database.",
+		"flag": "g", "format": "B",
+		"value": 3189825536
 	}
 }`
 
@@ -218,20 +228,26 @@ func Test_parseStats_Full(t *testing.T) {
 				RanDry:        float64(0),
 			},
 		},
+		book: map[string]*bookDefinition{
+			"book1": {
+				Alloc: 			float64(3189825536),
+			},
+		},
 	}
 
 	expectedBackends := map[string]*backendDefinition{
 		"boot.web1": {
-			Happy:       float64(0),
-			ReqHeader:   float64(381),
-			ReqBody:     float64(0),
-			RespHeader:  float64(229),
-			RespBody:    float64(2326),
-			PipeHeader:  float64(0),
-			PipeOut:     float64(0),
-			PipeIn:      float64(0),
-			Connections: float64(0),
-			Req:         float64(1),
+			Happy:           float64(0),
+			ReqHeader:       float64(381),
+			ReqBody:         float64(0),
+			RespHeader:      float64(229),
+			RespBody:        float64(2326),
+			PipeHeader:      float64(0),
+			PipeOut:         float64(0),
+			PipeIn:          float64(0),
+			Connections:     float64(0),
+			Req:             float64(1),
+			UnhealtyFetches: float64(1),
 		},
 	}
 

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -186,6 +186,16 @@ const varnishStatTestResult = `{
 		"description": "Number of bytes used in the book database.",
 		"flag": "g", "format": "B",
 		"value": 3189825536
+	},
+	"MSE_BOOK.book1.g_space": {
+		"description": "Number of bytes available in the book database.",
+		"flag": "g", "format": "B",
+		"value": 2178883584
+	},
+	"MSE_BOOK.book1.c_waterlevel_purge": {
+		"description": "Number of objects purged to achieve database waterlevel",
+		"flag": "c", "format": "i",
+		"value": 106000
 	}
 }`
 
@@ -231,6 +241,8 @@ func Test_parseStats_Full(t *testing.T) {
 		book: map[string]*bookDefinition{
 			"book1": {
 				Alloc: 			float64(3189825536),
+				Available:		float64(2178883584),
+				PurgeObjects: 	float64(106000),
 			},
 		},
 	}

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -240,9 +240,9 @@ func Test_parseStats_Full(t *testing.T) {
 		},
 		book: map[string]*bookDefinition{
 			"book1": {
-				Alloc: 			float64(3189825536),
-				Available:		float64(2178883584),
-				PurgeObjects: 	float64(106000),
+				Alloc:        float64(3189825536),
+				Available:    float64(2178883584),
+				PurgeObjects: float64(106000),
 			},
 		},
 	}

--- a/src/metrics/stat_parse_test.go
+++ b/src/metrics/stat_parse_test.go
@@ -192,6 +192,11 @@ const varnishStatTestResult = `{
 		"flag": "g", "format": "B",
 		"value": 2178883584
 	},
+	"MSE_BOOK.book1.c_waterlevel_queue": {
+		"description": "Number of times a thread has been queued waiting for database space",
+		"flag": "c", "format": "i",
+		"value": 2
+	},
 	"MSE_BOOK.book1.c_waterlevel_purge": {
 		"description": "Number of objects purged to achieve database waterlevel",
 		"flag": "c", "format": "i",
@@ -242,6 +247,7 @@ func Test_parseStats_Full(t *testing.T) {
 			"book1": {
 				Alloc:        float64(3189825536),
 				Available:    float64(2178883584),
+				ThreadQueued: float64(2),
 				PurgeObjects: float64(106000),
 			},
 		},


### PR DESCRIPTION
This PR adds some MSE_BOOK - `book` and MSE_STORE - `store` Varnish Plus metrics.

All new properties are covered with tests.

It also has been tested with Varnish Plus in a (`dev`) environment and it works by sending appropriate metrics to New Relic.

The only issue (might not be related to this PR at all) is that the data is visible under NR Query Builder:
![query_builder_varnish_plus](https://user-images.githubusercontent.com/6328360/140067932-744ab595-5020-411c-bceb-5f4fa3b819f3.jpg)

But not under NR Data Explorer: (and yes, the timeframe was the same for both)
<img width="1264" alt="data_explorer_varnish_plus" src="https://user-images.githubusercontent.com/6328360/140067989-6d9f491c-3d2c-4d57-92bd-420b5c7ff6f0.png">

