### PR TITLE
fix(errorHandling): handle directory not found and permission errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- Fixed error management while checking existence of varnish.params file
+
 ## v2.6.0 - 2024-10-14
 
 ### dependency

--- a/src/main.go
+++ b/src/main.go
@@ -127,7 +127,7 @@ func collectParamsFile(systemEntity *integration.Entity, argsParamLoc string) er
 // Debian/Ubuntu and RHEL/CentOS systems.
 func determineParamsFileLoc(argsParamLoc string) (*string, error) {
 	if argsParamLoc != "" {
-		if _, err := os.Stat(argsParamLoc); os.IsNotExist(err) {
+		if _, err := os.Stat(argsParamLoc); err != nil {
 			return nil, err
 		}
 		return &argsParamLoc, nil
@@ -135,17 +135,18 @@ func determineParamsFileLoc(argsParamLoc string) (*string, error) {
 
 	// Try Debian/Ubuntu path
 	paramsLoc := debianUbuntuParamsLoc
-	if _, err := os.Stat(paramsLoc); !os.IsNotExist(err) {
+	if _, err := os.Stat(paramsLoc); err == nil {
 		return &paramsLoc, nil
 	}
 
 	// Try RHEL/CentOS
 	paramsLoc = rhelCentosParamsLoc
-	if _, err := os.Stat(paramsLoc); !os.IsNotExist(err) {
+	if _, err := os.Stat(paramsLoc); err == nil {
 		return &paramsLoc, nil
 	}
 
-	return nil, errors.New("varnish.params file could not be found")
+	errParamsFileNotFound := errors.New("varnish.params file could not be found at the specified paths")
+	return nil, fmt.Errorf("%w: %s or %s", errParamsFileNotFound, debianUbuntuParamsLoc, rhelCentosParamsLoc)
 }
 
 func parseParamsFile(file *os.File) (map[string]string, error) {

--- a/src/main.go
+++ b/src/main.go
@@ -24,9 +24,10 @@ const (
 )
 
 var (
-	integrationVersion = "0.0.0"
-	gitCommit          = ""
-	buildDate          = ""
+	integrationVersion    = "0.0.0"
+	gitCommit             = ""
+	buildDate             = ""
+	errParamsFileNotFound = errors.New("varnish.params file could not be found at the specified paths")
 )
 
 func main() {
@@ -145,7 +146,6 @@ func determineParamsFileLoc(argsParamLoc string) (*string, error) {
 		return &paramsLoc, nil
 	}
 
-	errParamsFileNotFound := errors.New("varnish.params file could not be found at the specified paths")
 	return nil, fmt.Errorf("%w: %s or %s", errParamsFileNotFound, debianUbuntuParamsLoc, rhelCentosParamsLoc)
 }
 


### PR DESCRIPTION
### Background

While I was working on a [help-request](https://newrelic.slack.com/archives/CP2EWSX7C/p1727863670936269) which we got in #help-virtuoso regarding varnish integration is failing for a customer.  When I tried to replicate the issue, I observed a bug in varnish package.

#### Scenario:

When the location of varnish.params isn't specified, the determineParamsFileLoc function tries to check the default locations debianUbuntuParamsLoc and rhelCentosParamsLoc for varnish.params. However, the error handling isn't proper. os.IsNotExist() will return false if there are any permission errors or directory not found errors. os.IsNotExist checks if there is a regular expression like 'no such file or directory'; if it finds this string in the error, then it returns true. As we are using this [here](https://github.com/newrelic/nri-varnish/blob/7bcd8179cdaf6d095ab1c1688a14708eff7e6221/src/main.go#L138) and [here](https://github.com/newrelic/nri-varnish/blob/7bcd8179cdaf6d095ab1c1688a14708eff7e6221/src/main.go#L144), since there is no directory format for me, we are going into the if condition and returning the default path, and trying to open the varnish.params file [here](https://github.com/newrelic/nri-varnish/blob/7bcd8179cdaf6d095ab1c1688a14708eff7e6221/src/main.go#L101), which throws an "open /etc/default/varnish/varnish.params is not a directory" error. We shouldn't reach this point if we don't have the varnish.params file. Additionally, we aren't handling any other errors like file permission errors. I have made changes to handle all errors.

I have tried using Varnish 7.1 and identified this issue. As shown below, I have a file called varnish at the /etc/default location. However, when we try to search for /etc/default/varnish/varnish.params, we get a 'not a directory' error. This is because !os.IsNotExist(err) returns true here due to the regular expression not containing the 'no such file or directory' expression.


![image](https://github.com/user-attachments/assets/75bef4fe-be40-4957-a36b-1c2e3f2b79fc)

![image](https://github.com/user-attachments/assets/6cc3c81c-6dcf-4c81-bd23-8413c82d3479)

### Changes:
- Corrected error handling in determineParamsFileLoc function.
