### PR TITLE
Rollback CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v2.6.2 - 2024-12-16
-
-### ⛓️ Dependencies
-- Updated golang patch version to v1.23.4
-
 ## v2.6.1 - 2024-10-28
 
 ### 🐞 Bug fixes


### PR DESCRIPTION
Revert changelog to retrigger the prerelease of Renovate bumps